### PR TITLE
Remove Firebase

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeHotReload)
     alias(libs.plugins.sqldelight)
-    alias(libs.plugins.google.services)
 }
 
 kotlin {
@@ -38,8 +37,6 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.sqldelight.androidDriver)
-            implementation(libs.firebase.auth.ktx)
-            implementation(libs.firebase.auth)
         }
         commonMain.dependencies {
             implementation(libs.sqldelight.runtime)
@@ -78,7 +75,6 @@ kotlin {
         }
         iosMain.dependencies {
             implementation(libs.sqldelight.nativeDriver)
-            implementation(libs.firebase.auth)
         }
     }
 }

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -6,7 +6,6 @@ import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
-import com.google.firebase.FirebaseApp
 import org.koin.dsl.module
 import org.weekendware.basil.di.initKoin
 
@@ -17,7 +16,6 @@ import org.weekendware.basil.di.initKoin
  * - Enables edge-to-edge display so content draws behind system bars.
  * - Initialises Koin, passing `applicationContext` as a Koin singleton so
  *   that [DatabaseDriverFactory] can receive it via `get<Context>()`.
- * - Initialises Firebase.
  * - Sets the Compose content root to [App].
  */
 class MainActivity : ComponentActivity() {
@@ -29,7 +27,6 @@ class MainActivity : ComponentActivity() {
         initKoin {
             modules(module { single<android.content.Context> { applicationContext } })
         }
-        FirebaseApp.initializeApp(this)
 
         setContent {
             App()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,8 +12,6 @@ androidx-lifecycle = "2.9.0"
 androidx-testExt = "1.2.1"
 composeHotReload = "1.0.0-alpha10"
 composeMultiplatform = "1.8.1"
-firebaseAuth = "1.8.0"
-firebaseAuthKtx = "23.2.1"
 junit = "4.13.2"
 koinCore = "4.0.4"
 kotlin = "2.1.21"
@@ -27,8 +25,6 @@ voyagerNavigator = "1.0.0"
 
 
 [libraries]
-firebase-auth = { module = "dev.gitlive:firebase-auth", version.ref = "firebaseAuth" }
-firebase-auth-ktx = { module = "com.google.firebase:firebase-auth-ktx", version.ref = "firebaseAuthKtx" }
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinCore" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -65,4 +61,3 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
-google-services = { id = "com.google.gms.google-services", version = "4.4.0" }


### PR DESCRIPTION
## Summary
- Removes dev.gitlive:firebase-auth, firebase-auth-ktx, and the google-services plugin
- Removes FirebaseApp.initializeApp() from MainActivity
- Auth will be handled by Supabase
- Crashlytics excluded — not HIPAA-eligible under Google's BAA

## Test plan
- [x] Compiles cleanly on Android and Desktop
- [x] No Firebase references remain in source