### PR TITLE
Add Detekt static analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,39 @@ concurrency:
 
 jobs:
   # ──────────────────────────────────────────────────────────────
+  # Detekt static analysis
+  # ──────────────────────────────────────────────────────────────
+  detekt:
+    name: Detekt
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.ref != 'refs/heads/main' }}
+
+      - name: Run Detekt
+        run: ./gradlew detekt --no-daemon
+
+      - name: Upload Detekt report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: detekt-report
+          path: build/reports/detekt/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # ──────────────────────────────────────────────────────────────
   # Android: compile + unit tests + assemble debug APK
   # ──────────────────────────────────────────────────────────────
   android:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,4 +6,23 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.detekt)
+}
+
+detekt {
+    buildUponDefaultConfig = true
+    config.setFrom(files("$rootDir/config/detekt/detekt.yml"))
+    source.setFrom(
+        files(
+            "composeApp/src/commonMain/kotlin",
+            "composeApp/src/androidMain/kotlin",
+            "composeApp/src/iosMain/kotlin",
+            "composeApp/src/desktopMain/kotlin"
+        )
+    )
+    parallel = true
+}
+
+dependencies {
+    detektPlugins(libs.detekt.formatting)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import cafe.adriel.voyager.core.screen.Screen
 import org.koin.compose.koinInject
-import org.weekendware.basil.domain.model.BgUnit
 import org.weekendware.basil.domain.model.LogEntry
 import org.weekendware.basil.presentation.logging.LogEntrySheet
 import org.weekendware.basil.presentation.logging.LoggingViewModel
@@ -59,7 +58,6 @@ object DashboardScreen : Screen {
         val spacing = MaterialTheme.basilSpacing
 
         Box(modifier = Modifier.fillMaxSize()) {
-
             LazyColumn(
                 modifier = Modifier.fillMaxSize(),
                 contentPadding = PaddingValues(

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -1,0 +1,203 @@
+build:
+  maxIssues: 0
+
+config:
+  validation: true
+  warningsAsErrors: false
+
+# ─────────────────────────────────────────────────────────────
+# Formatting (ktlint rules via detekt-formatting)
+# ─────────────────────────────────────────────────────────────
+formatting:
+  active: true
+  android: false
+  autoCorrect: false
+
+  AnnotationOnSeparateLine:
+    active: false
+  ChainWrapping:
+    active: true
+  EnumEntryNameCase:
+    active: true
+  Filename:
+    active: false  # main.kt is the Compose Desktop convention; we use multi-declaration files
+  FinalNewline:
+    active: true
+  ImportOrdering:
+    active: false   # Android Studio manages imports
+  Indentation:
+    active: true
+    indentSize: 4
+  MaximumLineLength:
+    active: true
+    maxLineLength: 140
+  ModifierOrdering:
+    active: true
+  NoBlankLineBeforeRbrace:
+    active: true
+  NoConsecutiveBlankLines:
+    active: true
+  NoEmptyClassBody:
+    active: true
+  NoLineBreakAfterElse:
+    active: true
+  NoLineBreakBeforeAssignment:
+    active: true
+  NoMultipleSpaces:
+    active: false  # intentional alignment style used throughout
+  NoSemicolons:
+    active: true
+  NoTrailingSpaces:
+    active: true
+  NoUnitReturn:
+    active: true
+  NoUnusedImports:
+    active: true
+  NoWildcardImports:
+    active: true
+  SpacingAroundColon:
+    active: true
+  SpacingAroundComma:
+    active: true
+  SpacingAroundCurly:
+    active: true
+  SpacingAroundKeyword:
+    active: true
+  SpacingAroundOperators:
+    active: true
+  SpacingAroundParens:
+    active: true
+  SpacingAroundRangeOperator:
+    active: true
+  SpacingBetweenDeclarationsWithComments:
+    active: false  # too noisy with section separator comments
+  StringTemplate:
+    active: true
+
+# ─────────────────────────────────────────────────────────────
+# Code smell / complexity
+# ─────────────────────────────────────────────────────────────
+complexity:
+  active: true
+  LongParameterList:
+    active: true
+    functionThreshold: 7
+    constructorThreshold: 7
+  TooManyFunctions:
+    active: true
+    thresholdInFiles: 20
+    thresholdInClasses: 15
+    thresholdInObjects: 15
+    thresholdInInterfaces: 10
+    ignorePrivate: true
+    ignoreOverridden: true
+  LongMethod:
+    active: true
+    threshold: 100  # Composable UI functions are legitimately long
+  CyclomaticComplexMethod:
+    active: true
+    threshold: 15
+  LargeClass:
+    active: true
+    threshold: 300
+  NestedBlockDepth:
+    active: true
+    threshold: 4
+
+# ─────────────────────────────────────────────────────────────
+# Naming
+# ─────────────────────────────────────────────────────────────
+naming:
+  active: true
+  ClassNaming:
+    active: true
+    classPattern: '[A-Z][a-zA-Z0-9]*'
+  FunctionNaming:
+    active: true
+    functionPattern: '([a-zA-Z][a-zA-Z0-9]*)|(`.*`)'  # allow PascalCase for iOS ObjC exports + backtick test names
+    ignoreAnnotated:
+      - 'Composable'
+  VariableNaming:
+    active: true
+    variablePattern: '[a-z][A-Za-z0-9]*'
+  PackageNaming:
+    active: true
+    packagePattern: '[a-z]+(\.[a-z][A-Za-z0-9]*)*'
+  TopLevelPropertyNaming:
+    active: true
+    constantPattern: '[A-Z][_A-Z0-9]*'
+    propertyPattern: '[a-z][A-Za-z0-9]*|Local[A-Z][A-Za-z0-9]*'  # allow Compose CompositionLocals
+    privatePropertyPattern: '_?[a-z][A-Za-z0-9]*'
+  BooleanPropertyNaming:
+    active: false  # conflicts with Compose state names like showSheet
+  MatchingDeclarationName:
+    active: false  # we use utility/formatter files with multiple related declarations
+
+# ─────────────────────────────────────────────────────────────
+# Potential bugs
+# ─────────────────────────────────────────────────────────────
+potential-bugs:
+  active: true
+  EqualsAlwaysReturnsTrueOrFalse:
+    active: true
+  EqualsWithHashCodeExist:
+    active: true
+  ExplicitGarbageCollectionCall:
+    active: true
+  IteratorHasNextCallsNextMethod:
+    active: true
+  IteratorNotThrowingNoSuchElementException:
+    active: true
+  NullableToStringCall:
+    active: true
+  UnreachableCode:
+    active: true
+  UnsafeCallOnNullableType:
+    active: true
+  UnsafeCast:
+    active: true
+  UselessPostfixExpression:
+    active: true
+
+# ─────────────────────────────────────────────────────────────
+# Style
+# ─────────────────────────────────────────────────────────────
+style:
+  active: true
+  MagicNumber:
+    active: false   # health values and thresholds are self-documenting
+  WildcardImport:
+    active: true
+  UnusedPrivateMember:
+    active: true
+  ReturnCount:
+    active: true
+    max: 4
+  ThrowsCount:
+    active: true
+    max: 3
+  ForbiddenComment:
+    active: true
+    comments:
+      - reason: 'Ship blocker — must be resolved before merging'
+        value: 'STOPSHIP'
+      - reason: 'Unfinished fix — address before merging'
+        value: 'FIXME'
+  UnnecessaryAbstractClass:
+    active: true
+  UseDataClass:
+    active: false  # too aggressive for ViewModels and state holders
+  MaxLineLength:
+    active: false  # handled by formatting rules above
+
+# ─────────────────────────────────────────────────────────────
+# Coroutines
+# ─────────────────────────────────────────────────────────────
+coroutines:
+  active: true
+  GlobalCoroutineUsage:
+    active: true
+  RedundantSuspendModifier:
+    active: true
+  SuspendFunWithFlowReturnType:
+    active: true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlinx-coroutines = "1.10.2"
 kotlinxDatetime = "0.6.0"
 materialIconsExtended = "1.7.3"
 sqldelight = "2.0.1"
+detekt = "1.23.7"
 mockitoKotlin = "5.4.0"
 voyagerAnimations = "<version>"
 voyagerNavigator = "1.0.0"
@@ -27,6 +28,7 @@ voyagerNavigator = "1.0.0"
 [libraries]
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinCore" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
+detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-testJunit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutinesTest = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines" }
@@ -55,6 +57,7 @@ voyager-transitions = { module = "cafe.adriel.voyager:voyager-transitions", vers
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
+detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 androidLibrary = { id = "com.android.library", version.ref = "agp" }
 composeHotReload = { id = "org.jetbrains.compose.hot-reload", version.ref = "composeHotReload" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }


### PR DESCRIPTION
## What changed
Adds Detekt 1.23.7 with ktlint-style formatting rules across all KMP source sets.

## Why
Enforce consistent code style and catch common issues automatically on every PR.

## Details
- Config at config/detekt/detekt.yml — tuned for Compose KMP
- Intentional alignment style (NoMultipleSpaces) preserved
- Composable naming exceptions, CompositionLocal naming allowed
- Detekt job added to CI — zero issues on current codebase

## Test plan
- [x] `./gradlew detekt` passes locally with 0 issues
- [x] CI job configured