### PR TITLE
Repository interfaces and SqlDelight implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,98 @@
-# 🧬 Basil – Type 1 Diabetes, Simplified
-*Built with ❤️ by WeekendWare*
+# Basil – Type 1 Diabetes Management
+*Built by WeekendWare*
 
-Basil is a Kotlin Multiplatform app designed to make life with Type 1 diabetes a little easier—and a lot smarter. It’s not just another glucose log; it’s your co-pilot in the daily grind of chronic illness, built with empathy, intelligence, and an eye for good UX.
+Basil is a Kotlin Multiplatform app for managing life with Type 1 diabetes. One codebase, three targets — Android, iOS, and desktop — built with Compose Multiplatform, a clean layered architecture, and an emphasis on correctness.
 
 ---
 
-## 🔮 What’s Coming
+## Targets
 
-We’re just getting started. Here’s what’s on the roadmap:
+| Platform | Status |
+|---|---|
+| Android | Running |
+| iOS (Simulator) | Running |
+| Desktop (JVM) | Running |
 
-- 📊 **Insulin + carb logging** with intuitive inputs
-- 🕰 **Automated trend analysis** (CGM-style without the CGM)
-- 💡 **Smart suggestions** based on your patterns
-- 📓 **Context-aware journaling** for meals, stress, sleep
-- 🤖 **LLM-based assistant** trained to speak fluent T1D
+---
 
-## 🌱 Why Basil (Basal)?
+## Architecture
 
-Because living with T1D is hard enough—you deserve tools that *get it*.  
-Not medical, not preachy—just helpful, beautiful, and on your side.
+```
+presentation/          Compose UI + ViewModels (MVVM)
+domain/model/          Pure Kotlin domain models — no framework dependencies
+data/repository/       Repository interfaces + SQLDelight implementations
+data/local/database/   SQLDelight schema, generated queries, DatabaseDriverFactory
+di/                    Koin modules — shared + platform-specific
+```
 
-## 🧼 License
+Each layer depends only on the layer below it. ViewModels and use cases depend on repository *interfaces*, not the SQLDelight implementations — keeping them testable without a real database.
 
-**MIT License**  
-Built with code, care, and the quiet belief that tech can be both powerful and kind.
+---
+
+## Stack
+
+| Concern | Library |
+|---|---|
+| UI | Compose Multiplatform 1.8.1 |
+| Navigation | Voyager 1.0.0 |
+| DI | Koin 4.0.4 |
+| Database | SQLDelight 2.0.1 |
+| Date/Time | kotlinx-datetime 0.6.0 |
+| Static analysis | Detekt 1.23.7 + detekt-formatting (ktlint) |
+| Testing | kotlin-test + Mockito-Kotlin 5.4.0 |
+
+---
+
+## What's Built
+
+- **Dashboard** — last BG reading summary card with glucose status colouring, today's entry timeline, empty states
+- **Log entry sheet** — bottom sheet for logging BG, insulin, and carbs; validates and persists via `LogRepository`
+- **Preferences** — persisted BG unit preference (mg/dL or mmol/L) via `PreferencesRepository`
+- **Theme system** — custom `BasilColors`, `BasilSpacing`, `BasilTypography`, `BasilShapes` wired into MaterialTheme
+- **Repository layer** — `LogRepository`, `PreferencesRepository`, `UserRepository` interfaces with SQLDelight-backed implementations
+- **CI/CD** — GitHub Actions running Detekt, Android compile + test, and iOS framework build on every push
+
+---
+
+## What's Next
+
+- Flow-based SQLDelight queries (live UI updates)
+- Coroutine-scoped ViewModels
+- Use case layer
+- `Result<T>` error handling
+- Migrate to Compose Multiplatform Navigation
+- Build flavors (dev / staging / prod)
+- Supabase auth + user session
+- Sentry crash reporting
+
+---
+
+## Running Locally
+
+**Android**
+```
+./gradlew :composeApp:assembleDebug
+```
+
+**Desktop**
+```
+./gradlew :composeApp:run
+```
+
+**iOS** — open `iosApp/iosApp.xcodeproj` in Xcode and run on any iOS 16+ simulator.
+
+**Tests**
+```
+./gradlew desktopTest
+```
+
+**Static analysis**
+```
+./gradlew detekt
+```
+
+---
+
+## License
+
+MIT

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/LogRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/LogRepository.kt
@@ -1,40 +1,28 @@
 package org.weekendware.basil.data.repository
 
-import kotlinx.datetime.Clock
-import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.BgUnit
 import org.weekendware.basil.domain.model.LogEntry
-import orgweekendwarebasil.database.LogEntry as LogEntryEntity
 
 /**
- * Repository for [LogEntry] persistence.
+ * Contract for [LogEntry] persistence.
  *
- * Provides the single source of truth for all log entry data, mapping
- * between the SQLDelight-generated [LogEntryEntity] and the domain [LogEntry]
- * model. All database interactions for log entries should go through this class.
- *
- * @param database The [BasilDatabase] instance injected via Koin.
+ * Abstracts the storage mechanism so ViewModels and use cases depend only
+ * on this interface, not on any specific database implementation.
  */
-class LogRepository(private val database: BasilDatabase) {
+interface LogRepository {
 
     /**
      * Returns the most recent log entries, ordered by timestamp descending.
      *
      * @param limit Maximum number of entries to return. Defaults to 20.
-     * @return A list of [LogEntry] domain models, newest first.
      */
-    fun getRecent(limit: Long = 20): List<LogEntry> =
-        database.logEntryQueries.selectRecent(limit).executeAsList().map { it.toDomain() }
+    fun getRecent(limit: Long = 20): List<LogEntry>
 
     /**
      * Inserts a new log entry with the current timestamp.
      *
-     * At least one of the value parameters should be non-null for the entry
-     * to be meaningful, but the repository does not enforce this — validation
-     * is the responsibility of the calling ViewModel.
-     *
      * @param bgValue      Blood glucose reading, or null if not recorded.
-     * @param bgUnit       Unit for [bgValue]. Should be non-null whenever [bgValue] is non-null.
+     * @param bgUnit       Unit for [bgValue]. Should be non-null when [bgValue] is non-null.
      * @param insulinUnits Insulin dose in units, or null if not recorded.
      * @param carbsGrams   Carbohydrate intake in grams, or null if not recorded.
      */
@@ -43,31 +31,12 @@ class LogRepository(private val database: BasilDatabase) {
         bgUnit:       BgUnit?,
         insulinUnits: Double?,
         carbsGrams:   Double?
-    ) {
-        database.logEntryQueries.insertEntry(
-            timestamp     = Clock.System.now().toEpochMilliseconds(),
-            bg_value      = bgValue,
-            bg_unit       = bgUnit?.name,
-            insulin_units = insulinUnits,
-            carbs_grams   = carbsGrams
-        )
-    }
+    )
 
     /**
      * Deletes a single log entry by its database ID.
      *
      * @param id The primary key of the entry to delete.
      */
-    fun delete(id: Long) = database.logEntryQueries.deleteEntry(id)
-
-    // ── Mapping ───────────────────────────────────────────────
-
-    private fun LogEntryEntity.toDomain() = LogEntry(
-        id           = id,
-        timestamp    = timestamp,
-        bgValue      = bg_value,
-        bgUnit       = bg_unit?.let { runCatching { BgUnit.valueOf(it) }.getOrNull() },
-        insulinUnits = insulin_units,
-        carbsGrams   = carbs_grams
-    )
+    fun delete(id: Long)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PreferencesRepository.kt
@@ -1,45 +1,26 @@
 package org.weekendware.basil.data.repository
 
-import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.BgUnit
 
 /**
- * Repository for lightweight key-value user preferences.
+ * Contract for user preference persistence.
  *
- * Backed by the `Preferences` SQLite table. Each preference is stored as a
- * `TEXT` value under a unique string key. As new preferences are added to
- * the app, define their keys as constants in the companion object and add
- * typed accessor methods below.
- *
- * @param database The [BasilDatabase] instance injected via Koin.
+ * Abstracts the storage mechanism so ViewModels and use cases depend only
+ * on this interface, not on any specific database implementation.
  */
-class PreferencesRepository(private val database: BasilDatabase) {
-
-    companion object {
-        /** Key for the user's preferred blood glucose unit. */
-        private const val BG_UNIT_KEY = "bg_unit"
-    }
+interface PreferencesRepository {
 
     /**
      * Returns the user's preferred [BgUnit].
      *
-     * Defaults to [BgUnit.MGDL] if no preference has been saved yet or if
-     * the stored value cannot be parsed (e.g. after a schema change).
+     * Defaults to [BgUnit.MGDL] if no preference has been saved yet.
      */
-    fun getBgUnit(): BgUnit {
-        val value = database.preferencesQueries.get(BG_UNIT_KEY).executeAsOneOrNull()
-        return value?.let { runCatching { BgUnit.valueOf(it) }.getOrNull() } ?: BgUnit.MGDL
-    }
+    fun getBgUnit(): BgUnit
 
     /**
      * Persists the user's preferred [BgUnit].
      *
-     * Uses `INSERT OR REPLACE` semantics so calling this multiple times with
-     * different values always reflects the latest choice.
-     *
      * @param unit The [BgUnit] to store.
      */
-    fun setBgUnit(unit: BgUnit) {
-        database.preferencesQueries.set(BG_UNIT_KEY, unit.name)
-    }
+    fun setBgUnit(unit: BgUnit)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightLogRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightLogRepository.kt
@@ -1,0 +1,48 @@
+package org.weekendware.basil.data.repository
+
+import org.weekendware.basil.database.BasilDatabase
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.model.LogEntry
+import orgweekendwarebasil.database.LogEntry as LogEntryEntity
+
+/**
+ * SQLDelight-backed implementation of [LogRepository].
+ *
+ * Wraps the generated [BasilDatabase.logEntryQueries] and maps between the
+ * database entity and the domain [LogEntry] model.
+ *
+ * @param database The [BasilDatabase] instance injected via Koin.
+ */
+class SqlDelightLogRepository(private val database: BasilDatabase) : LogRepository {
+
+    override fun getRecent(limit: Long): List<LogEntry> =
+        database.logEntryQueries.selectRecent(limit).executeAsList().map { it.toDomain() }
+
+    override fun insert(
+        bgValue: Double?,
+        bgUnit: BgUnit?,
+        insulinUnits: Double?,
+        carbsGrams: Double?
+    ) {
+        database.logEntryQueries.insertEntry(
+            timestamp = System.currentTimeMillis(),
+            bg_value = bgValue,
+            bg_unit = bgUnit?.name,
+            insulin_units = insulinUnits,
+            carbs_grams = carbsGrams
+        )
+    }
+
+    override fun delete(id: Long) = database.logEntryQueries.deleteEntry(id)
+
+    // ── Mapping ───────────────────────────────────────────────
+
+    private fun LogEntryEntity.toDomain() = LogEntry(
+        id = id,
+        bgValue = bg_value,
+        bgUnit = bg_unit?.let { runCatching { BgUnit.valueOf(it) }.getOrNull() },
+        insulinUnits = insulin_units,
+        carbsGrams = carbs_grams,
+        timestamp = timestamp
+    )
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightLogRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightLogRepository.kt
@@ -1,5 +1,6 @@
 package org.weekendware.basil.data.repository
 
+import kotlinx.datetime.Clock
 import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.BgUnit
 import org.weekendware.basil.domain.model.LogEntry
@@ -25,7 +26,7 @@ class SqlDelightLogRepository(private val database: BasilDatabase) : LogReposito
         carbsGrams: Double?
     ) {
         database.logEntryQueries.insertEntry(
-            timestamp = System.currentTimeMillis(),
+            timestamp = Clock.System.now().toEpochMilliseconds(),
             bg_value = bgValue,
             bg_unit = bgUnit?.name,
             insulin_units = insulinUnits,

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightPreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightPreferencesRepository.kt
@@ -1,0 +1,29 @@
+package org.weekendware.basil.data.repository
+
+import org.weekendware.basil.database.BasilDatabase
+import org.weekendware.basil.domain.model.BgUnit
+
+/**
+ * SQLDelight-backed implementation of [PreferencesRepository].
+ *
+ * Backed by the `Preferences` SQLite table. Each preference is stored as a
+ * `TEXT` value under a unique string key.
+ *
+ * @param database The [BasilDatabase] instance injected via Koin.
+ */
+class SqlDelightPreferencesRepository(private val database: BasilDatabase) : PreferencesRepository {
+
+    companion object {
+        /** Key for the user's preferred blood glucose unit. */
+        private const val BG_UNIT_KEY = "bg_unit"
+    }
+
+    override fun getBgUnit(): BgUnit {
+        val value = database.preferencesQueries.get(BG_UNIT_KEY).executeAsOneOrNull()
+        return value?.let { runCatching { BgUnit.valueOf(it) }.getOrNull() } ?: BgUnit.MGDL
+    }
+
+    override fun setBgUnit(unit: BgUnit) {
+        database.preferencesQueries.set(BG_UNIT_KEY, unit.name)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -1,0 +1,28 @@
+package org.weekendware.basil.data.repository
+
+import org.weekendware.basil.database.BasilDatabase
+import org.weekendware.basil.domain.model.User
+import orgweekendwarebasil.database.User as UserEntity
+
+/**
+ * SQLDelight-backed implementation of [UserRepository].
+ *
+ * Wraps the generated [BasilDatabase.userQueries] and maps between the
+ * database entity and the domain [User] model.
+ *
+ * @param database The [BasilDatabase] instance injected via Koin.
+ */
+class SqlDelightUserRepository(private val database: BasilDatabase) : UserRepository {
+
+    override fun getAll(): List<User> =
+        database.userQueries.selectAll().executeAsList().map { it.toDomain() }
+
+    override fun insert(id: String, name: String, email: String) =
+        database.userQueries.insertUser(id, name, email)
+
+    override fun deleteAll() = database.userQueries.deleteAll()
+
+    // ── Mapping ───────────────────────────────────────────────
+
+    private fun UserEntity.toDomain() = User(id = id, name = name, email = email)
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/UserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/UserRepository.kt
@@ -1,28 +1,19 @@
 package org.weekendware.basil.data.repository
 
-import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.User
-import orgweekendwarebasil.database.User as UserEntity
 
 /**
- * Repository for [User] persistence.
+ * Contract for [User] persistence.
  *
- * Wraps the SQLDelight-generated `UserQueries` and maps between the
- * database entity and the domain [User] model. As user-related features
- * (profile setup, onboarding) are built out, query methods will be added here.
- *
- * @param database The [BasilDatabase] instance injected via Koin.
+ * Abstracts the storage mechanism so ViewModels and use cases depend only
+ * on this interface, not on any specific database implementation.
  */
-class UserRepository(private val database: BasilDatabase) {
+interface UserRepository {
 
     /**
      * Returns all users in the database, mapped to [User] domain models.
-     *
-     * In practice the app currently stores a single user, but the query is
-     * kept as `selectAll` to match the schema and remain extensible.
      */
-    fun getAll(): List<User> =
-        database.userQueries.selectAll().executeAsList().map { it.toDomain() }
+    fun getAll(): List<User>
 
     /**
      * Inserts a new user record.
@@ -31,17 +22,12 @@ class UserRepository(private val database: BasilDatabase) {
      * @param name  The user's display name.
      * @param email The user's email address.
      */
-    fun insert(id: String, name: String, email: String) =
-        database.userQueries.insertUser(id, name, email)
+    fun insert(id: String, name: String, email: String)
 
     /**
      * Deletes all user records. Used during development and reset flows.
      *
      * **Caution:** This is destructive and permanent.
      */
-    fun deleteAll() = database.userQueries.deleteAll()
-
-    // ── Mapping ───────────────────────────────────────────────
-
-    private fun UserEntity.toDomain() = User(id = id, name = name, email = email)
+    fun deleteAll()
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -4,6 +4,9 @@ import org.koin.dsl.module
 import org.weekendware.basil.data.local.database.DatabaseProvider
 import org.weekendware.basil.data.repository.LogRepository
 import org.weekendware.basil.data.repository.PreferencesRepository
+import org.weekendware.basil.data.repository.SqlDelightLogRepository
+import org.weekendware.basil.data.repository.SqlDelightPreferencesRepository
+import org.weekendware.basil.data.repository.SqlDelightUserRepository
 import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.presentation.chat.ChatViewModel
 import org.weekendware.basil.presentation.dashboard.DashboardViewModel
@@ -20,9 +23,9 @@ import org.weekendware.basil.presentation.settings.SettingsViewModel
  */
 val databaseModule = module {
     single { DatabaseProvider.getDatabase(get()) }
-    single { UserRepository(get()) }
-    single { LogRepository(get()) }
-    single { PreferencesRepository(get()) }
+    single<UserRepository> { SqlDelightUserRepository(get()) }
+    single<LogRepository> { SqlDelightLogRepository(get()) }
+    single<PreferencesRepository> { SqlDelightPreferencesRepository(get()) }
 }
 
 /**

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/LogRepositoryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/LogRepositoryTest.kt
@@ -3,6 +3,7 @@ package org.weekendware.basil.data.repository
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.data.repository.SqlDelightLogRepository
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -12,13 +13,13 @@ import kotlin.test.assertTrue
 
 class LogRepositoryTest {
 
-    private lateinit var repository: LogRepository
+    private lateinit var repository: SqlDelightLogRepository
 
     @BeforeTest
     fun setup() {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BasilDatabase.Schema.create(driver)
-        repository = LogRepository(BasilDatabase(driver))
+        repository = SqlDelightLogRepository(BasilDatabase(driver))
     }
 
     // ── getRecent ─────────────────────────────────────────────

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/PreferencesRepositoryTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/PreferencesRepositoryTest.kt
@@ -1,6 +1,7 @@
 package org.weekendware.basil.data.repository
 
 import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import org.weekendware.basil.data.repository.SqlDelightPreferencesRepository
 import org.weekendware.basil.database.BasilDatabase
 import org.weekendware.basil.domain.model.BgUnit
 import kotlin.test.BeforeTest
@@ -9,13 +10,13 @@ import kotlin.test.assertEquals
 
 class PreferencesRepositoryTest {
 
-    private lateinit var repository: PreferencesRepository
+    private lateinit var repository: SqlDelightPreferencesRepository
 
     @BeforeTest
     fun setup() {
         val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
         BasilDatabase.Schema.create(driver)
-        repository = PreferencesRepository(BasilDatabase(driver))
+        repository = SqlDelightPreferencesRepository(BasilDatabase(driver))
     }
 
     // ── getBgUnit ─────────────────────────────────────────────


### PR DESCRIPTION
## What changed
- Converted `LogRepository`, `PreferencesRepository`, and `UserRepository` from concrete classes to interfaces
- Created `SqlDelightLogRepository`, `SqlDelightPreferencesRepository`, `SqlDelightUserRepository` as the concrete SQLDelight-backed implementations
- Koin DI binds each interface to its implementation (`single<LogRepository> { SqlDelightLogRepository(get()) }`)
- Integration tests updated to instantiate the `SqlDelight*` classes directly; ViewModel mock tests continue to target the interfaces

## Why
ViewModels and use cases should depend on abstractions, not concrete database classes. This makes the layer boundary explicit, keeps call sites mockable in tests, and is a prerequisite for the Flow-based query work.

## How to test
- `./gradlew desktopTest` — all 57 tests should pass
- `./gradlew detekt` — no issues

## Risk
Low. Purely structural rename + extract. No runtime behaviour changed; only Koin bindings updated.