### PR TITLE
Add CoroutineScope to all ViewModels

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
@@ -1,5 +1,8 @@
 package org.weekendware.basil.presentation.chat
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -9,8 +12,13 @@ import kotlinx.coroutines.flow.StateFlow
  * Currently a placeholder. As the AI assistant feature is implemented,
  * this ViewModel will manage the conversation message list, handle
  * LLM API requests, and surface loading/error states.
+ *
+ * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class ChatViewModel {
+class ChatViewModel(
+    @Suppress("UnusedPrivateMember")
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) {
     private val _title = MutableStateFlow("Basil")
 
     /** The screen title, used as a placeholder until the chat UI is built. */

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
@@ -1,5 +1,8 @@
 package org.weekendware.basil.presentation.logging
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -43,8 +46,10 @@ data class LogFormState(
  * @param preferencesRepository Persists and retrieves user preferences.
  */
 class LoggingViewModel(
-    private val logRepository:         LogRepository,
-    private val preferencesRepository: PreferencesRepository
+    private val logRepository: LogRepository,
+    private val preferencesRepository: PreferencesRepository,
+    @Suppress("UnusedPrivateMember")
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) {
     private val _state = MutableStateFlow(LogFormState())
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
@@ -1,5 +1,8 @@
 package org.weekendware.basil.presentation.profile
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -10,8 +13,13 @@ import kotlinx.coroutines.flow.StateFlow
  * ViewModel will expose and manage the user's health profile data,
  * loading it from the database via a `UserRepository` and coordinating
  * saves when the user edits their profile.
+ *
+ * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class ProfileViewModel {
+class ProfileViewModel(
+    @Suppress("UnusedPrivateMember")
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) {
     private val _title = MutableStateFlow("Profile")
 
     /** The screen title, used as a placeholder until the profile UI is built. */

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
@@ -1,5 +1,8 @@
 package org.weekendware.basil.presentation.settings
 
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -10,8 +13,13 @@ import kotlinx.coroutines.flow.StateFlow
  * notification preferences, theme selection, etc.) this ViewModel will
  * expose state flows for each setting and coordinate persistence via
  * [PreferencesRepository].
+ *
+ * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class SettingsViewModel {
+class SettingsViewModel(
+    @Suppress("UnusedPrivateMember")
+    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+) {
     private val _title = MutableStateFlow("Settings")
 
     /** The screen title, displayed in the top app bar. */


### PR DESCRIPTION
## What changed
- `LoggingViewModel`, `SettingsViewModel`, `ProfileViewModel`, `ChatViewModel` each gain a `coroutineScope: CoroutineScope` parameter with a default of `CoroutineScope(SupervisorJob() + Dispatchers.Default)`
- `DashboardViewModel` already had this from item 5

## Why
All ViewModels now have a consistent, injectable scope. When async operations are added in items 7–8 (use case layer, Result<T> error handling), the infrastructure is already in place — no further ViewModel refactoring needed. Tests can pass a `TestScope` to control coroutine execution.

## How to test
- `./gradlew desktopTest` — all 57 tests pass
- `./gradlew detekt` — no issues

## Risk
None. Default parameter — all existing Koin DI and test call sites are unchanged.