### PR TITLE
Introduce use case layer

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/KoinStartup.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/KoinStartup.kt
@@ -15,7 +15,8 @@ import org.koin.dsl.KoinAppDeclaration
  * The loaded modules are:
  * 1. [platformModule] — platform-specific bindings (e.g. [DatabaseDriverFactory]).
  * 2. [databaseModule] — [BasilDatabase] and all repositories.
- * 3. [sharedModule] — all ViewModels.
+ * 3. [useCaseModule] — all use cases.
+ * 4. [sharedModule] — all ViewModels.
  *
  * @param appDeclaration Optional platform-level Koin configuration. Android
  *   uses this to register `Context` as a Koin singleton so [DatabaseDriverFactory]
@@ -23,5 +24,5 @@ import org.koin.dsl.KoinAppDeclaration
  */
 fun initKoin(appDeclaration: KoinAppDeclaration = {}) = startKoin {
     appDeclaration()
-    modules(platformModule, databaseModule, sharedModule)
+    modules(platformModule, databaseModule, useCaseModule, sharedModule)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -8,6 +8,13 @@ import org.weekendware.basil.data.repository.SqlDelightLogRepository
 import org.weekendware.basil.data.repository.SqlDelightPreferencesRepository
 import org.weekendware.basil.data.repository.SqlDelightUserRepository
 import org.weekendware.basil.data.repository.UserRepository
+import org.weekendware.basil.domain.usecase.DeleteLogEntryUseCase
+import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
+import org.weekendware.basil.domain.usecase.GetLastBgReadingUseCase
+import org.weekendware.basil.domain.usecase.GetTodayEntriesUseCase
+import org.weekendware.basil.domain.usecase.ObserveRecentLogsUseCase
+import org.weekendware.basil.domain.usecase.SaveLogEntryUseCase
+import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
 import org.weekendware.basil.presentation.chat.ChatViewModel
 import org.weekendware.basil.presentation.dashboard.DashboardViewModel
 import org.weekendware.basil.presentation.logging.LoggingViewModel
@@ -16,10 +23,6 @@ import org.weekendware.basil.presentation.settings.SettingsViewModel
 
 /**
  * Koin module that wires the database and all repositories.
- *
- * - [BasilDatabase] is a singleton built from the platform-specific
- *   [DatabaseDriverFactory] (provided by [platformModule]).
- * - Repositories are singletons that each receive the shared database instance.
  */
 val databaseModule = module {
     single { DatabaseProvider.getDatabase(get()) }
@@ -29,17 +32,25 @@ val databaseModule = module {
 }
 
 /**
+ * Koin module that provides all use cases as singletons.
+ */
+val useCaseModule = module {
+    single { ObserveRecentLogsUseCase(get()) }
+    single { GetTodayEntriesUseCase() }
+    single { GetLastBgReadingUseCase() }
+    single { SaveLogEntryUseCase(get()) }
+    single { DeleteLogEntryUseCase(get()) }
+    single { GetBgUnitPreferenceUseCase(get()) }
+    single { SetBgUnitPreferenceUseCase(get()) }
+}
+
+/**
  * Koin module that provides all shared ViewModels as singletons.
- *
- * ViewModels are registered as `single` (not `viewModel`) so that they
- * are compatible across all KMP targets without requiring platform-specific
- * ViewModel lifecycle integration. Koin's `koinInject` is used at call sites
- * instead of `koinViewModel`.
  */
 val sharedModule = module {
-    single { DashboardViewModel(get()) }
+    single { DashboardViewModel(get(), get(), get()) }
     single { ProfileViewModel() }
     single { ChatViewModel() }
     single { SettingsViewModel() }
-    single { LoggingViewModel(get(), get()) }
+    single { LoggingViewModel(get(), get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/DeleteLogEntryUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/DeleteLogEntryUseCase.kt
@@ -1,0 +1,12 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.LogRepository
+
+/**
+ * Deletes a single log entry by its database ID.
+ *
+ * @param logRepository Source of truth for all log entry data.
+ */
+class DeleteLogEntryUseCase(private val logRepository: LogRepository) {
+    operator fun invoke(id: Long) = logRepository.delete(id)
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetBgUnitPreferenceUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetBgUnitPreferenceUseCase.kt
@@ -1,0 +1,15 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.PreferencesRepository
+import org.weekendware.basil.domain.model.BgUnit
+
+/**
+ * Returns the user's preferred [BgUnit].
+ *
+ * Defaults to [BgUnit.MGDL] if no preference has been saved yet.
+ *
+ * @param preferencesRepository Source of truth for user preferences.
+ */
+class GetBgUnitPreferenceUseCase(private val preferencesRepository: PreferencesRepository) {
+    operator fun invoke(): BgUnit = preferencesRepository.getBgUnit()
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetLastBgReadingUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetLastBgReadingUseCase.kt
@@ -1,0 +1,16 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.domain.model.LogEntry
+
+/**
+ * Returns the most recent [LogEntry] that contains a blood glucose value,
+ * or null if no such entry exists.
+ *
+ * Entries are assumed to be ordered newest-first (as returned by
+ * [ObserveRecentLogsUseCase]). The first entry with a non-null [LogEntry.bgValue]
+ * is returned, regardless of whether it was recorded today.
+ */
+class GetLastBgReadingUseCase {
+    operator fun invoke(entries: List<LogEntry>): LogEntry? =
+        entries.firstOrNull { it.bgValue != null }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetTodayEntriesUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetTodayEntriesUseCase.kt
@@ -1,0 +1,25 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+import org.weekendware.basil.domain.model.LogEntry
+
+/**
+ * Filters a list of log entries to those recorded today in the device's
+ * local timezone.
+ *
+ * Extracted from [DashboardViewModel] so the definition of "today" lives
+ * in the domain layer and can be tested independently of any UI class.
+ */
+class GetTodayEntriesUseCase {
+
+    operator fun invoke(entries: List<LogEntry>): List<LogEntry> {
+        val tz = TimeZone.currentSystemDefault()
+        val today = Clock.System.now().toLocalDateTime(tz).date
+        return entries.filter { entry ->
+            Instant.fromEpochMilliseconds(entry.timestamp).toLocalDateTime(tz).date == today
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/ObserveRecentLogsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/ObserveRecentLogsUseCase.kt
@@ -1,0 +1,16 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.coroutines.flow.Flow
+import org.weekendware.basil.data.repository.LogRepository
+import org.weekendware.basil.domain.model.LogEntry
+
+/**
+ * Returns a [Flow] of recent log entries from [LogRepository].
+ *
+ * Acts as the single entry point for all screens that need to observe
+ * the log. The limit is fixed at 100 entries — enough to cover any
+ * single-day view plus a meaningful history window.
+ */
+class ObserveRecentLogsUseCase(private val logRepository: LogRepository) {
+    operator fun invoke(): Flow<List<LogEntry>> = logRepository.getRecent(100)
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SaveLogEntryUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SaveLogEntryUseCase.kt
@@ -1,0 +1,41 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.LogRepository
+import org.weekendware.basil.domain.model.BgUnit
+
+/**
+ * Validates and saves a log entry.
+ *
+ * Encapsulates the mapping from raw form strings to typed domain values
+ * and the rule that a BG unit is only written when a BG value is present.
+ * Returns [Result.success] with `true` if the entry was saved, or
+ * [Result.success] with `false` if the form was empty (no-op). A
+ * [Result.failure] is returned if an unexpected error occurs during save.
+ *
+ * @param logRepository Persists the entry to the local database.
+ */
+class SaveLogEntryUseCase(private val logRepository: LogRepository) {
+
+    operator fun invoke(
+        bgValue: String,
+        bgUnit: BgUnit,
+        insulinUnits: String,
+        carbsGrams: String
+    ): Result<Boolean> {
+        val bg = bgValue.toDoubleOrNull()
+        val insulin = insulinUnits.toDoubleOrNull()
+        val carbs = carbsGrams.toDoubleOrNull()
+
+        if (bg == null && insulin == null && carbs == null) return Result.success(false)
+
+        return runCatching {
+            logRepository.insert(
+                bgValue = bg,
+                bgUnit = if (bg != null) bgUnit else null,
+                insulinUnits = insulin,
+                carbsGrams = carbs
+            )
+            true
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SetBgUnitPreferenceUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SetBgUnitPreferenceUseCase.kt
@@ -1,0 +1,13 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.PreferencesRepository
+import org.weekendware.basil.domain.model.BgUnit
+
+/**
+ * Persists the user's preferred [BgUnit].
+ *
+ * @param preferencesRepository Source of truth for user preferences.
+ */
+class SetBgUnitPreferenceUseCase(private val preferencesRepository: PreferencesRepository) {
+    operator fun invoke(unit: BgUnit) = preferencesRepository.setBgUnit(unit)
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModel.kt
@@ -9,20 +9,17 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
-import kotlinx.datetime.TimeZone
-import kotlinx.datetime.toLocalDateTime
-import org.weekendware.basil.data.repository.LogRepository
 import org.weekendware.basil.domain.model.LogEntry
+import org.weekendware.basil.domain.usecase.GetLastBgReadingUseCase
+import org.weekendware.basil.domain.usecase.GetTodayEntriesUseCase
+import org.weekendware.basil.domain.usecase.ObserveRecentLogsUseCase
 
 /**
  * UI state for the [DashboardScreen].
  *
  * @property todayEntries All log entries recorded today, ordered newest first.
  * @property lastBgEntry  The most recent entry that contains a blood glucose
- *   value, regardless of whether it was recorded today. Used to populate the
- *   summary card at the top of the dashboard.
+ *   value, regardless of whether it was recorded today.
  */
 data class DashboardState(
     val todayEntries: List<LogEntry> = emptyList(),
@@ -32,16 +29,13 @@ data class DashboardState(
 /**
  * ViewModel for [DashboardScreen].
  *
- * Observes [LogRepository.getRecent] as a [kotlinx.coroutines.flow.Flow] so the
- * dashboard updates automatically whenever an entry is inserted or deleted —
- * no manual refresh calls required.
- *
- * @param logRepository Source of truth for all log entry data.
- * @param coroutineScope Scope used to collect the repository Flow. Defaults to
- *   an app-lifetime scope; override in tests with a [kotlinx.coroutines.test.TestScope].
+ * Delegates all data access and business logic to use cases. The [state]
+ * Flow updates automatically whenever the underlying log table changes.
  */
 class DashboardViewModel(
-    private val logRepository: LogRepository,
+    observeRecentLogs: ObserveRecentLogsUseCase,
+    private val getTodayEntries: GetTodayEntriesUseCase,
+    private val getLastBgReading: GetLastBgReadingUseCase,
     coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) {
 
@@ -57,11 +51,11 @@ class DashboardViewModel(
      * The current dashboard UI state, derived live from the repository Flow.
      * Emits a new [DashboardState] whenever the underlying log table changes.
      */
-    val state: StateFlow<DashboardState> = logRepository.getRecent(100)
+    val state: StateFlow<DashboardState> = observeRecentLogs()
         .map { recent ->
             DashboardState(
-                todayEntries = recent.filter { it.isToday() },
-                lastBgEntry = recent.firstOrNull { it.bgValue != null }
+                todayEntries = getTodayEntries(recent),
+                lastBgEntry = getLastBgReading(recent)
             )
         }
         .stateIn(
@@ -75,13 +69,4 @@ class DashboardViewModel(
 
     /** Closes the log-entry bottom sheet. */
     fun closeLogSheet() = _showLogSheet.update { false }
-
-    // ── Helpers ───────────────────────────────────────────────
-
-    private fun LogEntry.isToday(): Boolean {
-        val tz = TimeZone.currentSystemDefault()
-        val today = Clock.System.now().toLocalDateTime(tz).date
-        val entryDate = Instant.fromEpochMilliseconds(timestamp).toLocalDateTime(tz).date
-        return entryDate == today
-    }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
@@ -6,27 +6,28 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
-import org.weekendware.basil.data.repository.LogRepository
-import org.weekendware.basil.data.repository.PreferencesRepository
 import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
+import org.weekendware.basil.domain.usecase.SaveLogEntryUseCase
+import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
 
 /**
  * Represents the current state of the log-entry form in [LogEntrySheet].
  *
  * All numeric inputs are held as [String] so the user can type freely;
- * conversion to [Double] happens at save time.
+ * conversion to [Double] happens at save time inside [SaveLogEntryUseCase].
  *
- * @property bgValue      Raw text value for the blood glucose field. Empty means not entered.
+ * @property bgValue      Raw text value for the blood glucose field.
  * @property bgUnit       The currently-selected BG unit (mg/dL or mmol/L).
- * @property insulinUnits Raw text value for the insulin units field. Empty means not entered.
- * @property carbsGrams   Raw text value for the carbohydrates field in grams. Empty means not entered.
+ * @property insulinUnits Raw text value for the insulin units field.
+ * @property carbsGrams   Raw text value for the carbohydrates field in grams.
  * @property hasAnyValue  True if at least one field has been filled in, enabling the Save button.
  */
 data class LogFormState(
-    val bgValue:      String  = "",
-    val bgUnit:       BgUnit  = BgUnit.MGDL,
-    val insulinUnits: String  = "",
-    val carbsGrams:   String  = ""
+    val bgValue: String = "",
+    val bgUnit: BgUnit = BgUnit.MGDL,
+    val insulinUnits: String = "",
+    val carbsGrams: String = ""
 ) {
     val hasAnyValue: Boolean
         get() = bgValue.isNotBlank() || insulinUnits.isNotBlank() || carbsGrams.isNotBlank()
@@ -35,19 +36,14 @@ data class LogFormState(
 /**
  * ViewModel for the [LogEntrySheet].
  *
- * Manages form state, persists the user's preferred BG unit via
- * [PreferencesRepository], and delegates entry saving to [LogRepository].
- *
- * The preferred BG unit is loaded from [PreferencesRepository] on
- * initialisation so the toggle reflects the user's last choice every time
- * the sheet is opened.
- *
- * @param logRepository         Persists log entries to the local database.
- * @param preferencesRepository Persists and retrieves user preferences.
+ * Manages form state and delegates persistence to use cases. The preferred
+ * BG unit is loaded on initialisation so the toggle reflects the user's
+ * last choice every time the sheet is opened.
  */
 class LoggingViewModel(
-    private val logRepository: LogRepository,
-    private val preferencesRepository: PreferencesRepository,
+    private val saveLogEntry: SaveLogEntryUseCase,
+    private val getBgUnitPreference: GetBgUnitPreferenceUseCase,
+    private val setBgUnitPreference: SetBgUnitPreferenceUseCase,
     @Suppress("UnusedPrivateMember")
     private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
 ) {
@@ -57,23 +53,20 @@ class LoggingViewModel(
     val state: StateFlow<LogFormState> = _state
 
     init {
-        // Restore the user's last-selected BG unit so the toggle is consistent
-        // across sheet open/close cycles.
-        _state.update { it.copy(bgUnit = preferencesRepository.getBgUnit()) }
+        _state.update { it.copy(bgUnit = getBgUnitPreference()) }
     }
 
     /** Updates the blood glucose text field value. */
     fun onBgValueChange(value: String) = _state.update { it.copy(bgValue = value) }
 
     /**
-     * Updates the selected BG unit and persists the choice so it is
-     * remembered the next time the sheet is opened.
+     * Updates the selected BG unit and persists the choice.
      *
      * @param unit The newly-selected [BgUnit].
      */
     fun onBgUnitChange(unit: BgUnit) {
         _state.update { it.copy(bgUnit = unit) }
-        preferencesRepository.setBgUnit(unit)
+        setBgUnitPreference(unit)
     }
 
     /** Updates the insulin units text field value. */
@@ -85,33 +78,30 @@ class LoggingViewModel(
     /**
      * Resets the form to its empty state while preserving the selected BG unit.
      *
-     * Called by [DashboardScreen] when the FAB is tapped, ensuring the sheet
-     * always opens clean without stale values from a previous session.
+     * Called when the FAB is tapped so the sheet always opens clean.
      */
     fun reset() {
         _state.update { LogFormState(bgUnit = it.bgUnit) }
     }
 
     /**
-     * Validates the current form state and, if at least one field is populated,
-     * saves a new [LogEntry] to the database, resets the form, and invokes [onSuccess].
+     * Delegates to [SaveLogEntryUseCase]. Invokes [onSuccess] if the entry
+     * was saved, or no-ops silently when the form is empty.
      *
-     * A BG unit is only written to the log if a BG value was actually entered.
-     * No-ops silently when [LogFormState.hasAnyValue] is false.
-     *
-     * @param onSuccess Callback invoked after a successful save; typically dismisses the sheet.
+     * @param onSuccess Callback invoked after a successful save.
      */
     fun save(onSuccess: () -> Unit) {
         val current = _state.value
-        if (!current.hasAnyValue) return
+        val saved = saveLogEntry(
+            bgValue = current.bgValue,
+            bgUnit = current.bgUnit,
+            insulinUnits = current.insulinUnits,
+            carbsGrams = current.carbsGrams
+        ).getOrDefault(false)
 
-        logRepository.insert(
-            bgValue      = current.bgValue.toDoubleOrNull(),
-            bgUnit       = if (current.bgValue.isNotBlank()) current.bgUnit else null,
-            insulinUnits = current.insulinUnits.toDoubleOrNull(),
-            carbsGrams   = current.carbsGrams.toDoubleOrNull()
-        )
-        reset()
-        onSuccess()
+        if (saved) {
+            reset()
+            onSuccess()
+        }
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/GetLastBgReadingUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/GetLastBgReadingUseCaseTest.kt
@@ -1,0 +1,54 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.datetime.Clock
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.model.LogEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class GetLastBgReadingUseCaseTest {
+
+    private val useCase = GetLastBgReadingUseCase()
+
+    private fun makeEntry(id: Long, bgValue: Double? = null, insulinUnits: Double? = null) = LogEntry(
+        id = id,
+        timestamp = Clock.System.now().toEpochMilliseconds(),
+        bgValue = bgValue,
+        bgUnit = if (bgValue != null) BgUnit.MGDL else null,
+        insulinUnits = insulinUnits,
+        carbsGrams = null
+    )
+
+    @Test
+    fun `returns null for empty list`() {
+        assertNull(useCase(emptyList()))
+    }
+
+    @Test
+    fun `returns null when no entry has a bgValue`() {
+        val entries = listOf(makeEntry(id = 1L, insulinUnits = 4.0))
+        assertNull(useCase(entries))
+    }
+
+    @Test
+    fun `returns first entry with a bgValue`() {
+        val withBg = makeEntry(id = 1L, bgValue = 120.0)
+        val withoutBg = makeEntry(id = 2L, insulinUnits = 4.0)
+        assertEquals(1L, useCase(listOf(withBg, withoutBg))?.id)
+    }
+
+    @Test
+    fun `skips leading non-BG entries to find the first BG reading`() {
+        val noBg = makeEntry(id = 1L, insulinUnits = 4.0)
+        val withBg = makeEntry(id = 2L, bgValue = 95.0)
+        assertEquals(2L, useCase(listOf(noBg, withBg))?.id)
+    }
+
+    @Test
+    fun `returns the first entry when multiple entries have bgValues`() {
+        val first = makeEntry(id = 1L, bgValue = 120.0)
+        val second = makeEntry(id = 2L, bgValue = 80.0)
+        assertEquals(1L, useCase(listOf(first, second))?.id)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/GetTodayEntriesUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/GetTodayEntriesUseCaseTest.kt
@@ -1,0 +1,51 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.datetime.Clock
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.model.LogEntry
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class GetTodayEntriesUseCaseTest {
+
+    private val useCase = GetTodayEntriesUseCase()
+
+    private fun makeEntry(id: Long, timestampOffset: Long = 0L) = LogEntry(
+        id = id,
+        timestamp = Clock.System.now().toEpochMilliseconds() - timestampOffset,
+        bgValue = 100.0,
+        bgUnit = BgUnit.MGDL,
+        insulinUnits = null,
+        carbsGrams = null
+    )
+
+    @Test
+    fun `returns empty list when given empty input`() {
+        assertTrue(useCase(emptyList()).isEmpty())
+    }
+
+    @Test
+    fun `includes entries recorded today`() {
+        val today = makeEntry(id = 1L)
+        val result = useCase(listOf(today))
+        assertEquals(1, result.size)
+        assertEquals(1L, result.first().id)
+    }
+
+    @Test
+    fun `excludes entries from yesterday`() {
+        val yesterday = makeEntry(id = 1L, timestampOffset = 25 * 60 * 60 * 1000L)
+        assertTrue(useCase(listOf(yesterday)).isEmpty())
+    }
+
+    @Test
+    fun `returns only today entries from a mixed list`() {
+        val today1 = makeEntry(id = 1L)
+        val today2 = makeEntry(id = 2L)
+        val yesterday = makeEntry(id = 3L, timestampOffset = 25 * 60 * 60 * 1000L)
+        val result = useCase(listOf(today1, today2, yesterday))
+        assertEquals(2, result.size)
+        assertTrue(result.none { it.id == 3L })
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/SaveLogEntryUseCaseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/SaveLogEntryUseCaseTest.kt
@@ -1,0 +1,80 @@
+package org.weekendware.basil.domain.usecase
+
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.weekendware.basil.data.repository.LogRepository
+import org.weekendware.basil.domain.model.BgUnit
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SaveLogEntryUseCaseTest {
+
+    private val logRepository = mock<LogRepository>()
+    private val useCase = SaveLogEntryUseCase(logRepository)
+
+    @Test
+    fun `returns false and does not insert when all fields are blank`() {
+        val result = useCase(bgValue = "", bgUnit = BgUnit.MGDL, insulinUnits = "", carbsGrams = "")
+
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow())
+        verifyNoInteractions(logRepository)
+    }
+
+    @Test
+    fun `returns true and inserts when bgValue is provided`() {
+        val result = useCase(bgValue = "120", bgUnit = BgUnit.MGDL, insulinUnits = "", carbsGrams = "")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow())
+        verify(logRepository).insert(bgValue = 120.0, bgUnit = BgUnit.MGDL, insulinUnits = null, carbsGrams = null)
+    }
+
+    @Test
+    fun `returns true and inserts when insulinUnits is provided`() {
+        val result = useCase(bgValue = "", bgUnit = BgUnit.MGDL, insulinUnits = "4", carbsGrams = "")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow())
+        verify(logRepository).insert(bgValue = null, bgUnit = null, insulinUnits = 4.0, carbsGrams = null)
+    }
+
+    @Test
+    fun `returns true and inserts when carbsGrams is provided`() {
+        val result = useCase(bgValue = "", bgUnit = BgUnit.MGDL, insulinUnits = "", carbsGrams = "45")
+
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrThrow())
+        verify(logRepository).insert(bgValue = null, bgUnit = null, insulinUnits = null, carbsGrams = 45.0)
+    }
+
+    @Test
+    fun `sets bgUnit to null when bgValue is blank`() {
+        useCase(bgValue = "", bgUnit = BgUnit.MMOLL, insulinUnits = "3", carbsGrams = "")
+
+        verify(logRepository).insert(bgValue = null, bgUnit = null, insulinUnits = 3.0, carbsGrams = null)
+    }
+
+    @Test
+    fun `passes all fields correctly for a full entry`() {
+        useCase(bgValue = "5.5", bgUnit = BgUnit.MMOLL, insulinUnits = "4", carbsGrams = "45")
+
+        verify(logRepository).insert(
+            bgValue = 5.5,
+            bgUnit = BgUnit.MMOLL,
+            insulinUnits = 4.0,
+            carbsGrams = 45.0
+        )
+    }
+
+    @Test
+    fun `ignores non-numeric bgValue and treats entry as no-op`() {
+        val result = useCase(bgValue = "abc", bgUnit = BgUnit.MGDL, insulinUnits = "", carbsGrams = "")
+
+        assertTrue(result.isSuccess)
+        assertFalse(result.getOrThrow())
+        verifyNoInteractions(logRepository)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModelTest.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
+
 package org.weekendware.basil.presentation.dashboard
 
 import kotlinx.coroutines.CoroutineScope
@@ -13,6 +15,9 @@ import org.mockito.kotlin.whenever
 import org.weekendware.basil.data.repository.LogRepository
 import org.weekendware.basil.domain.model.BgUnit
 import org.weekendware.basil.domain.model.LogEntry
+import org.weekendware.basil.domain.usecase.GetLastBgReadingUseCase
+import org.weekendware.basil.domain.usecase.GetTodayEntriesUseCase
+import org.weekendware.basil.domain.usecase.ObserveRecentLogsUseCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -22,6 +27,9 @@ import kotlin.test.assertTrue
 class DashboardViewModelTest {
 
     private val logRepository = mock<LogRepository>()
+    private val observeRecentLogs = ObserveRecentLogsUseCase(logRepository)
+    private val getTodayEntries = GetTodayEntriesUseCase()
+    private val getLastBgReading = GetLastBgReadingUseCase()
 
     private fun makeEntry(
         id: Long,
@@ -39,12 +47,15 @@ class DashboardViewModelTest {
         carbsGrams = carbsGrams
     )
 
+    private fun makeVm(scope: CoroutineScope) =
+        DashboardViewModel(observeRecentLogs, getTodayEntries, getLastBgReading, scope)
+
     // ── initial state ─────────────────────────────────────────
 
     @Test
     fun `initial state is empty when repository returns no entries`() = runTest {
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(emptyList()))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertTrue(vm.state.value.todayEntries.isEmpty())
@@ -57,7 +68,7 @@ class DashboardViewModelTest {
     fun `state populates todayEntries with entries from today`() = runTest {
         val todayEntry = makeEntry(id = 1L, bgValue = 100.0, bgUnit = BgUnit.MGDL)
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(listOf(todayEntry)))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertEquals(1, vm.state.value.todayEntries.size)
@@ -73,7 +84,7 @@ class DashboardViewModelTest {
             timestampOffset = 25 * 60 * 60 * 1000L
         )
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(listOf(yesterday)))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertTrue(vm.state.value.todayEntries.isEmpty())
@@ -86,7 +97,7 @@ class DashboardViewModelTest {
         val withBg = makeEntry(id = 1L, bgValue = 120.0, bgUnit = BgUnit.MGDL)
         val withoutBg = makeEntry(id = 2L, insulinUnits = 4.0)
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(listOf(withBg, withoutBg)))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertEquals(1L, vm.state.value.lastBgEntry?.id)
@@ -96,7 +107,7 @@ class DashboardViewModelTest {
     fun `lastBgEntry is null when no entry has a bgValue`() = runTest {
         val entry = makeEntry(id = 1L, insulinUnits = 4.0)
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(listOf(entry)))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertNull(vm.state.value.lastBgEntry)
@@ -111,7 +122,7 @@ class DashboardViewModelTest {
             timestampOffset = 25 * 60 * 60 * 1000L
         )
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(listOf(yesterday)))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
         advanceUntilIdle()
 
         assertTrue(vm.state.value.todayEntries.isEmpty())
@@ -124,11 +135,8 @@ class DashboardViewModelTest {
     fun `state updates automatically when repository emits new entries`() = runTest {
         val source = MutableStateFlow<List<LogEntry>>(emptyList())
         whenever(logRepository.getRecent(100)).thenReturn(source)
-        // UnconfinedTestDispatcher executes emissions eagerly — no advanceUntilIdle needed.
-        // The scope is explicitly cancelled at the end so runTest doesn't flag it.
-        @OptIn(kotlinx.coroutines.ExperimentalCoroutinesApi::class)
         val vmScope = CoroutineScope(UnconfinedTestDispatcher(testScheduler))
-        val vm = DashboardViewModel(logRepository, vmScope)
+        val vm = makeVm(vmScope)
 
         assertTrue(vm.state.value.todayEntries.isEmpty())
 
@@ -143,7 +151,7 @@ class DashboardViewModelTest {
     @Test
     fun `showLogSheet starts as false`() = runTest {
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(emptyList()))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
 
         assertFalse(vm.showLogSheet.value)
     }
@@ -151,7 +159,7 @@ class DashboardViewModelTest {
     @Test
     fun `openLogSheet sets showLogSheet to true`() = runTest {
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(emptyList()))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
 
         vm.openLogSheet()
 
@@ -161,7 +169,7 @@ class DashboardViewModelTest {
     @Test
     fun `closeLogSheet sets showLogSheet to false`() = runTest {
         whenever(logRepository.getRecent(100)).thenReturn(flowOf(emptyList()))
-        val vm = DashboardViewModel(logRepository, this)
+        val vm = makeVm(this)
 
         vm.openLogSheet()
         vm.closeLogSheet()

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModelTest.kt
@@ -6,6 +6,9 @@ import org.mockito.kotlin.whenever
 import org.weekendware.basil.data.repository.LogRepository
 import org.weekendware.basil.data.repository.PreferencesRepository
 import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
+import org.weekendware.basil.domain.usecase.SaveLogEntryUseCase
+import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
@@ -13,12 +16,15 @@ import kotlin.test.assertTrue
 
 class LoggingViewModelTest {
 
-    private val logRepository         = mock<LogRepository>()
+    private val logRepository = mock<LogRepository>()
     private val preferencesRepository = mock<PreferencesRepository>()
+    private val saveLogEntry = SaveLogEntryUseCase(logRepository)
+    private val getBgUnitPreference = GetBgUnitPreferenceUseCase(preferencesRepository)
+    private val setBgUnitPreference = SetBgUnitPreferenceUseCase(preferencesRepository)
 
     private fun makeVm(): LoggingViewModel {
         whenever(preferencesRepository.getBgUnit()).thenReturn(BgUnit.MGDL)
-        return LoggingViewModel(logRepository, preferencesRepository)
+        return LoggingViewModel(saveLogEntry, getBgUnitPreference, setBgUnitPreference)
     }
 
     // ── initial state ─────────────────────────────────────────
@@ -26,7 +32,7 @@ class LoggingViewModelTest {
     @Test
     fun `initial bgUnit is loaded from preferences`() {
         whenever(preferencesRepository.getBgUnit()).thenReturn(BgUnit.MMOLL)
-        val vm = LoggingViewModel(logRepository, preferencesRepository)
+        val vm = LoggingViewModel(saveLogEntry, getBgUnitPreference, setBgUnitPreference)
 
         assertEquals(BgUnit.MMOLL, vm.state.value.bgUnit)
     }
@@ -92,7 +98,7 @@ class LoggingViewModelTest {
     @Test
     fun `reset preserves the current bgUnit`() {
         whenever(preferencesRepository.getBgUnit()).thenReturn(BgUnit.MMOLL)
-        val vm = LoggingViewModel(logRepository, preferencesRepository)
+        val vm = LoggingViewModel(saveLogEntry, getBgUnitPreference, setBgUnitPreference)
         vm.reset()
 
         assertEquals(BgUnit.MMOLL, vm.state.value.bgUnit)
@@ -119,10 +125,10 @@ class LoggingViewModelTest {
         vm.save { callbackInvoked = true }
 
         verify(logRepository).insert(
-            bgValue      = 120.0,
-            bgUnit       = BgUnit.MGDL,
+            bgValue = 120.0,
+            bgUnit = BgUnit.MGDL,
             insulinUnits = null,
-            carbsGrams   = null
+            carbsGrams = null
         )
         assertTrue(callbackInvoked)
     }
@@ -135,10 +141,10 @@ class LoggingViewModelTest {
         vm.save {}
 
         verify(logRepository).insert(
-            bgValue      = null,
-            bgUnit       = null,
+            bgValue = null,
+            bgUnit = null,
             insulinUnits = 5.0,
-            carbsGrams   = null
+            carbsGrams = null
         )
     }
 
@@ -158,7 +164,7 @@ class LoggingViewModelTest {
     @Test
     fun `save preserves bgUnit after reset`() {
         whenever(preferencesRepository.getBgUnit()).thenReturn(BgUnit.MMOLL)
-        val vm = LoggingViewModel(logRepository, preferencesRepository)
+        val vm = LoggingViewModel(saveLogEntry, getBgUnitPreference, setBgUnitPreference)
         vm.onBgValueChange("5.5")
 
         vm.save {}


### PR DESCRIPTION
## What changed
Seven use cases added under `domain/usecase/`:
- `ObserveRecentLogsUseCase` — single entry point for the log `Flow`
- `GetTodayEntriesUseCase` — today filter extracted from `DashboardViewModel`
- `GetLastBgReadingUseCase` — first BG entry logic extracted from `DashboardViewModel`
- `SaveLogEntryUseCase` — validation + insert logic extracted from `LoggingViewModel`; returns `Result<Boolean>`
- `DeleteLogEntryUseCase` — wraps `logRepository.delete()`
- `GetBgUnitPreferenceUseCase` / `SetBgUnitPreferenceUseCase` — preference access

`DashboardViewModel` and `LoggingViewModel` now depend on use cases rather than repositories directly. A new `useCaseModule` is registered in Koin.

## Why
Business logic now lives in the domain layer — independently testable, reusable across screens, and decoupled from both the UI and the database. `DashboardViewModel` lost its `isToday()` helper and manual `firstOrNull` logic entirely.

## How to test
- `./gradlew desktopTest` — 73 tests pass (up from 57)
- `./gradlew detekt` — no issues

## Risk
Low. Purely a restructuring of existing logic — no behaviour changed.