### PR TITLE
Scope ViewModels to nav destinations via koinViewModel

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -53,6 +53,7 @@ kotlin {
             implementation(libs.material.icons.extended)
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
+            implementation(libs.koin.compose.viewmodel)
             implementation(libs.androidx.navigation.compose)
         }
         commonTest.dependencies {

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -1,5 +1,6 @@
 package org.weekendware.basil.di
 
+import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import org.weekendware.basil.data.local.database.DatabaseProvider
 import org.weekendware.basil.data.repository.LogRepository
@@ -48,9 +49,9 @@ val useCaseModule = module {
  * Koin module that provides all shared ViewModels as singletons.
  */
 val sharedModule = module {
-    single { DashboardViewModel(get(), get(), get()) }
-    single { ProfileViewModel() }
-    single { ChatViewModel() }
-    single { SettingsViewModel() }
-    single { LoggingViewModel(get(), get(), get()) }
+    viewModel { DashboardViewModel(get(), get(), get()) }
+    viewModel { ProfileViewModel() }
+    viewModel { ChatViewModel() }
+    viewModel { SettingsViewModel() }
+    viewModel { LoggingViewModel(get(), get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
@@ -3,7 +3,7 @@ package org.weekendware.basil.presentation.chat
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 /**
  * The Basil AI assistant screen.
@@ -15,7 +15,7 @@ import org.koin.compose.koinInject
  */
 @Composable
 fun ChatScreen() {
-    val viewModel = koinInject<ChatViewModel>()
+    val viewModel = koinViewModel<ChatViewModel>()
     val title = viewModel.title.collectAsState()
     Text(title.value)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
@@ -1,8 +1,6 @@
 package org.weekendware.basil.presentation.chat
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -12,13 +10,8 @@ import kotlinx.coroutines.flow.StateFlow
  * Currently a placeholder. As the AI assistant feature is implemented,
  * this ViewModel will manage the conversation message list, handle
  * LLM API requests, and surface loading/error states.
- *
- * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class ChatViewModel(
-    @Suppress("UnusedPrivateMember")
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) {
+class ChatViewModel : ViewModel() {
     private val _title = MutableStateFlow("Basil")
 
     /** The screen title, used as a placeholder until the chat UI is built. */

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
@@ -28,7 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.domain.model.LogEntry
 import org.weekendware.basil.presentation.logging.LogEntrySheet
 import org.weekendware.basil.presentation.logging.LoggingViewModel
@@ -48,8 +48,8 @@ import org.weekendware.basil.presentation.theme.basilSpacing
  */
 @Composable
 fun DashboardScreen() {
-    val viewModel = koinInject<DashboardViewModel>()
-    val loggingViewModel = koinInject<LoggingViewModel>()
+    val viewModel = koinViewModel<DashboardViewModel>()
+    val loggingViewModel = koinViewModel<LoggingViewModel>()
     val uiState by viewModel.state.collectAsState()
     val showSheet by viewModel.showLogSheet.collectAsState()
     val spacing = MaterialTheme.basilSpacing

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardViewModel.kt
@@ -1,8 +1,8 @@
 package org.weekendware.basil.presentation.dashboard
 
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -31,13 +31,18 @@ data class DashboardState(
  *
  * Delegates all data access and business logic to use cases. The [state]
  * Flow updates automatically whenever the underlying log table changes.
+ *
+ * @param coroutineScope Scope for async operations. Defaults to [viewModelScope]
+ *   when null. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
 class DashboardViewModel(
     observeRecentLogs: ObserveRecentLogsUseCase,
     private val getTodayEntries: GetTodayEntriesUseCase,
     private val getLastBgReading: GetLastBgReadingUseCase,
-    coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) {
+    coroutineScope: CoroutineScope? = null
+) : ViewModel() {
+
+    private val scope = coroutineScope ?: viewModelScope
 
     private val _showLogSheet = MutableStateFlow(false)
 
@@ -59,7 +64,7 @@ class DashboardViewModel(
             )
         }
         .stateIn(
-            scope = coroutineScope,
+            scope = scope,
             started = SharingStarted.Eagerly,
             initialValue = DashboardState()
         )

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LoggingViewModel.kt
@@ -1,8 +1,6 @@
 package org.weekendware.basil.presentation.logging
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -46,10 +44,9 @@ data class LogFormState(
 class LoggingViewModel(
     private val saveLogEntry: SaveLogEntryUseCase,
     private val getBgUnitPreference: GetBgUnitPreferenceUseCase,
-    private val setBgUnitPreference: SetBgUnitPreferenceUseCase,
-    @Suppress("UnusedPrivateMember")
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) {
+    private val setBgUnitPreference: SetBgUnitPreferenceUseCase
+) : ViewModel() {
+
     private val _state = MutableStateFlow(LogFormState())
 
     /** The current form state, observed by [LogEntrySheet]. */

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -3,7 +3,7 @@ package org.weekendware.basil.presentation.profile
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 
 /**
  * The user Profile screen.
@@ -17,7 +17,7 @@ import org.koin.compose.koinInject
  */
 @Composable
 fun ProfileScreen() {
-    val viewModel = koinInject<ProfileViewModel>()
+    val viewModel = koinViewModel<ProfileViewModel>()
     val title = viewModel.title.collectAsState()
     Text(title.value)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
@@ -1,8 +1,6 @@
 package org.weekendware.basil.presentation.profile
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -13,13 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
  * ViewModel will expose and manage the user's health profile data,
  * loading it from the database via a `UserRepository` and coordinating
  * saves when the user edits their profile.
- *
- * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class ProfileViewModel(
-    @Suppress("UnusedPrivateMember")
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) {
+class ProfileViewModel : ViewModel() {
     private val _title = MutableStateFlow("Profile")
 
     /** The screen title, used as a placeholder until the profile UI is built. */

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
@@ -8,7 +8,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
-import org.koin.compose.koinInject
+import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.presentation.theme.basilColors
 import org.weekendware.basil.presentation.theme.basilSpacing
 
@@ -21,7 +21,7 @@ import org.weekendware.basil.presentation.theme.basilSpacing
  */
 @Composable
 fun SettingsScreen() {
-    val viewModel = koinInject<SettingsViewModel>()
+    val viewModel = koinViewModel<SettingsViewModel>()
     val title = viewModel.title.collectAsState()
 
     Surface(

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
@@ -1,8 +1,6 @@
 package org.weekendware.basil.presentation.settings
 
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
+import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 
@@ -13,13 +11,8 @@ import kotlinx.coroutines.flow.StateFlow
  * notification preferences, theme selection, etc.) this ViewModel will
  * expose state flows for each setting and coordinate persistence via
  * [PreferencesRepository].
- *
- * @param coroutineScope Scope for async operations. Override in tests with a [kotlinx.coroutines.test.TestScope].
  */
-class SettingsViewModel(
-    @Suppress("UnusedPrivateMember")
-    private val coroutineScope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
-) {
+class SettingsViewModel : ViewModel() {
     private val _title = MutableStateFlow("Settings")
 
     /** The screen title, displayed in the top app bar. */

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -26,6 +26,7 @@ navigation = "2.8.0-alpha13"
 
 [libraries]
 koin-compose = { module = "io.insert-koin:koin-compose", version.ref = "koinCore" }
+koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", version.ref = "koinCore" }
 koin-core = { module = "io.insert-koin:koin-core", version.ref = "koinCore" }
 detekt-formatting = { module = "io.gitlab.arturbosch.detekt:detekt-formatting", version.ref = "detekt" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- All five ViewModels extend `androidx.lifecycle.ViewModel` and use `viewModelScope` for coroutines
- Koin `SharedModule` registers them with the `viewModel {}` DSL instead of `single {}`
- All screen composables inject via `koinViewModel<T>()` so Compose Navigation manages lifecycle scope per destination
- `DashboardViewModel` accepts an optional `CoroutineScope?` constructor param (defaults to `viewModelScope`) so existing unit tests continue to pass their own `TestScope`

## Test plan
- [ ] `./gradlew desktopTest` passes (15 tests)
- [ ] `./gradlew detekt` passes
- [ ] Run on iOS Simulator — navigate between all tabs and Settings, no crash