### PR TITLE
Add dev/staging/prod build flavors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,10 +54,13 @@ local.properties
 **/*.appiconset/*.png
 **/*.appiconset/*.jpg
 **/Preview Content/
-# Ignore personal/sensitive xcconfig overrides but keep the shared template
+# Ignore personal/sensitive xcconfig overrides but keep the shared templates
 **/Configuration/**
 !iosApp/Configuration/
 !iosApp/Configuration/Config.xcconfig
+!iosApp/Configuration/Dev.xcconfig
+!iosApp/Configuration/Staging.xcconfig
+!iosApp/Configuration/Prod.xcconfig
 
 # Unnecessary binaries (exclude intentional project screenshots)
 *.png

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.composeMultiplatform) apply false
     alias(libs.plugins.composeCompiler) apply false
     alias(libs.plugins.kotlinMultiplatform) apply false
+    alias(libs.plugins.buildkonfig) apply false
     alias(libs.plugins.detekt)
 }
 

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,3 +1,4 @@
+import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
 
 plugins {
@@ -7,6 +8,7 @@ plugins {
     alias(libs.plugins.composeCompiler)
     alias(libs.plugins.composeHotReload)
     alias(libs.plugins.sqldelight)
+    alias(libs.plugins.buildkonfig)
 }
 
 kotlin {
@@ -93,6 +95,25 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    flavorDimensions += "environment"
+    productFlavors {
+        create("dev") {
+            dimension = "environment"
+            applicationIdSuffix = ".dev"
+            versionNameSuffix = "-dev"
+            resValue("string", "app_name", "Basil Dev")
+        }
+        create("staging") {
+            dimension = "environment"
+            applicationIdSuffix = ".staging"
+            versionNameSuffix = "-staging"
+            resValue("string", "app_name", "Basil Staging")
+        }
+        create("prod") {
+            dimension = "environment"
+            resValue("string", "app_name", "Basil")
+        }
+    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false
@@ -116,6 +137,38 @@ compose.desktop {
             targetFormats(TargetFormat.Dmg, TargetFormat.Msi, TargetFormat.Deb)
             packageName = "org.weekendware.basil"
             packageVersion = "1.0.0"
+        }
+    }
+}
+
+buildkonfig {
+    packageName = "org.weekendware.basil"
+
+    // Prod defaults
+    defaultConfigs {
+        buildConfigField(STRING, "FLAVOR", "prod")
+        buildConfigField(STRING, "BASE_URL", "https://api.basil.app")
+    }
+    targetConfigs {
+        create("dev") {
+            buildConfigField(STRING, "FLAVOR", "dev")
+            buildConfigField(STRING, "BASE_URL", "https://dev-api.basil.app")
+        }
+        create("staging") {
+            buildConfigField(STRING, "FLAVOR", "staging")
+            buildConfigField(STRING, "BASE_URL", "https://staging-api.basil.app")
+        }
+    }
+}
+
+// Per-flavor desktop run tasks
+listOf("dev", "staging", "prod").forEach { flavor ->
+    tasks.register("runDesktop${flavor.replaceFirstChar { it.uppercase() }}") {
+        group = "application"
+        description = "Run desktop app with $flavor config"
+        dependsOn("desktopRun")
+        doFirst {
+            System.setProperty("app.flavor", flavor)
         }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ sqldelight = "2.0.1"
 detekt = "1.23.7"
 mockitoKotlin = "5.4.0"
 navigation = "2.8.0-alpha13"
+buildkonfig = "0.15.2"
 
 
 [libraries]
@@ -61,3 +62,4 @@ composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMul
 composeCompiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinMultiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 sqldelight = { id = "app.cash.sqldelight", version.ref = "sqldelight" }
+buildkonfig = { id = "com.codingfeline.buildkonfig", version.ref = "buildkonfig" }

--- a/iosApp/Configuration/Dev.xcconfig
+++ b/iosApp/Configuration/Dev.xcconfig
@@ -1,0 +1,6 @@
+#include "Config.xcconfig"
+
+APP_NAME = Basil Dev
+PRODUCT_NAME = Basil Dev
+PRODUCT_BUNDLE_IDENTIFIER = org.weekendware.basil.dev
+BASE_URL = https://dev-api.basil.app

--- a/iosApp/Configuration/Prod.xcconfig
+++ b/iosApp/Configuration/Prod.xcconfig
@@ -1,0 +1,6 @@
+#include "Config.xcconfig"
+
+APP_NAME = Basil
+PRODUCT_NAME = Basil
+PRODUCT_BUNDLE_IDENTIFIER = org.weekendware.basil
+BASE_URL = https://api.basil.app

--- a/iosApp/Configuration/Staging.xcconfig
+++ b/iosApp/Configuration/Staging.xcconfig
@@ -1,0 +1,6 @@
+#include "Config.xcconfig"
+
+APP_NAME = Basil Staging
+PRODUCT_NAME = Basil Staging
+PRODUCT_BUNDLE_IDENTIFIER = org.weekendware.basil.staging
+BASE_URL = https://staging-api.basil.app


### PR DESCRIPTION
## Summary
- **BuildKonfig** generates `BuildConfig.FLAVOR` and `BuildConfig.BASE_URL` in commonMain, accessible from all targets via expect/actual
- **Android**: `dev` (`.dev` suffix), `staging` (`.staging` suffix), `prod` flavors — all three can be installed side by side; app names set via `resValue`
- **iOS**: `Dev.xcconfig`, `Staging.xcconfig`, `Prod.xcconfig` each extend `Config.xcconfig` with environment-specific bundle ID, app name, and base URL
- **Desktop**: `runDesktopDev`, `runDesktopStaging`, `runDesktopProd` Gradle tasks

## Test plan
- [ ] `./gradlew desktopTest` passes
- [ ] `./gradlew detekt` passes
- [ ] `./gradlew :composeApp:assembleDevDebug` builds without error
- [ ] `./gradlew :composeApp:assembleStagingDebug` builds without error
- [ ] `./gradlew :composeApp:assembleProdDebug` builds without error