### PR TITLE
Add Supabase auth client and repository

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -1,5 +1,6 @@
 import com.codingfeline.buildkonfig.compiler.FieldSpec.Type.STRING
 import org.jetbrains.compose.desktop.application.dsl.TargetFormat
+import java.util.Properties
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -39,6 +40,7 @@ kotlin {
             implementation(compose.preview)
             implementation(libs.androidx.activity.compose)
             implementation(libs.sqldelight.androidDriver)
+            implementation(libs.ktor.client.okhttp)
         }
         commonMain.dependencies {
             implementation(libs.sqldelight.runtime)
@@ -57,6 +59,8 @@ kotlin {
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.androidx.navigation.compose)
+            implementation(libs.supabase.auth)
+            implementation(libs.ktor.client.core)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -66,6 +70,7 @@ kotlin {
             implementation(compose.desktop.currentOs)
             implementation(libs.kotlinx.coroutinesSwing)
             implementation(libs.sqlite.driver)
+            implementation(libs.ktor.client.java)
         }
         desktopTest.dependencies {
             implementation(libs.kotlin.testJunit)
@@ -75,6 +80,7 @@ kotlin {
         }
         iosMain.dependencies {
             implementation(libs.sqldelight.nativeDriver)
+            implementation(libs.ktor.client.darwin)
         }
     }
 }
@@ -141,22 +147,29 @@ compose.desktop {
     }
 }
 
+val localProps = Properties().apply {
+    val f = rootProject.file("local.properties")
+    if (f.exists()) load(f.inputStream())
+}
+
 buildkonfig {
     packageName = "org.weekendware.basil"
 
-    // Prod defaults
     defaultConfigs {
         buildConfigField(STRING, "FLAVOR", "prod")
-        buildConfigField(STRING, "BASE_URL", "https://api.basil.app")
+        buildConfigField(STRING, "SUPABASE_URL", localProps["supabase.prod.url"] as? String ?: "")
+        buildConfigField(STRING, "SUPABASE_ANON_KEY", localProps["supabase.prod.anonKey"] as? String ?: "")
     }
     targetConfigs {
         create("dev") {
             buildConfigField(STRING, "FLAVOR", "dev")
-            buildConfigField(STRING, "BASE_URL", "https://dev-api.basil.app")
+            buildConfigField(STRING, "SUPABASE_URL", localProps["supabase.dev.url"] as? String ?: "")
+            buildConfigField(STRING, "SUPABASE_ANON_KEY", localProps["supabase.dev.anonKey"] as? String ?: "")
         }
         create("staging") {
             buildConfigField(STRING, "FLAVOR", "staging")
-            buildConfigField(STRING, "BASE_URL", "https://staging-api.basil.app")
+            buildConfigField(STRING, "SUPABASE_URL", localProps["supabase.staging.url"] as? String ?: "")
+            buildConfigField(STRING, "SUPABASE_ANON_KEY", localProps["supabase.staging.anonKey"] as? String ?: "")
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/remote/SupabaseClientProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/remote/SupabaseClientProvider.kt
@@ -1,0 +1,20 @@
+package org.weekendware.basil.data.remote
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
+import io.github.jan.supabase.createSupabaseClient
+import org.weekendware.basil.BuildKonfig
+
+/**
+ * Creates and configures the shared [SupabaseClient] singleton.
+ *
+ * URL and anon key are injected from [BuildKonfig] at compile time, so
+ * dev / staging / prod each connect to their own Supabase project without
+ * any runtime switching logic.
+ */
+fun createSupabaseClient(): SupabaseClient = createSupabaseClient(
+    supabaseUrl = BuildKonfig.SUPABASE_URL,
+    supabaseKey = BuildKonfig.SUPABASE_ANON_KEY
+) {
+    install(Auth)
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
@@ -1,0 +1,25 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Contract for authentication operations.
+ *
+ * All methods return [Result] so callers can handle errors without
+ * catching exceptions directly.
+ */
+interface AuthRepository {
+
+    /** Signs up a new user with [email] and [password]. */
+    suspend fun signUp(email: String, password: String): Result<Unit>
+
+    /** Signs in an existing user with [email] and [password]. */
+    suspend fun signIn(email: String, password: String): Result<Unit>
+
+    /** Signs out the current user and clears the local session. */
+    suspend fun signOut(): Result<Unit>
+
+    /** Returns the currently authenticated user's ID, or null if signed out. */
+    fun currentUserId(): String?
+
+    /** True if a valid session exists. */
+    fun isSignedIn(): Boolean
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -1,0 +1,44 @@
+package org.weekendware.basil.data.repository
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.auth
+import io.github.jan.supabase.auth.providers.builtin.Email
+
+/**
+ * [AuthRepository] implementation backed by Supabase Auth.
+ *
+ * Session persistence is handled automatically by the supabase-kt Auth
+ * plugin — tokens are stored in platform-native secure storage and
+ * restored on the next app launch.
+ */
+class SupabaseAuthRepository(
+    private val client: SupabaseClient
+) : AuthRepository {
+
+    override suspend fun signUp(email: String, password: String): Result<Unit> =
+        runCatching {
+            client.auth.signUpWith(Email) {
+                this.email = email
+                this.password = password
+            }
+        }
+
+    override suspend fun signIn(email: String, password: String): Result<Unit> =
+        runCatching {
+            client.auth.signInWith(Email) {
+                this.email = email
+                this.password = password
+            }
+        }
+
+    override suspend fun signOut(): Result<Unit> =
+        runCatching {
+            client.auth.signOut()
+        }
+
+    override fun currentUserId(): String? =
+        client.auth.currentUserOrNull()?.id
+
+    override fun isSignedIn(): Boolean =
+        client.auth.currentUserOrNull() != null
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/KoinStartup.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/KoinStartup.kt
@@ -24,5 +24,5 @@ import org.koin.dsl.KoinAppDeclaration
  */
 fun initKoin(appDeclaration: KoinAppDeclaration = {}) = startKoin {
     appDeclaration()
-    modules(platformModule, databaseModule, useCaseModule, sharedModule)
+    modules(platformModule, supabaseModule, databaseModule, useCaseModule, sharedModule)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -3,11 +3,14 @@ package org.weekendware.basil.di
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 import org.weekendware.basil.data.local.database.DatabaseProvider
+import org.weekendware.basil.data.remote.createSupabaseClient
+import org.weekendware.basil.data.repository.AuthRepository
 import org.weekendware.basil.data.repository.LogRepository
 import org.weekendware.basil.data.repository.PreferencesRepository
 import org.weekendware.basil.data.repository.SqlDelightLogRepository
 import org.weekendware.basil.data.repository.SqlDelightPreferencesRepository
 import org.weekendware.basil.data.repository.SqlDelightUserRepository
+import org.weekendware.basil.data.repository.SupabaseAuthRepository
 import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.DeleteLogEntryUseCase
 import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
@@ -21,6 +24,14 @@ import org.weekendware.basil.presentation.dashboard.DashboardViewModel
 import org.weekendware.basil.presentation.logging.LoggingViewModel
 import org.weekendware.basil.presentation.profile.ProfileViewModel
 import org.weekendware.basil.presentation.settings.SettingsViewModel
+
+/**
+ * Koin module that wires the Supabase client and auth repository.
+ */
+val supabaseModule = module {
+    single { createSupabaseClient() }
+    single<AuthRepository> { SupabaseAuthRepository(get()) }
+}
 
 /**
  * Koin module that wires the database and all repositories.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,8 @@ detekt = "1.23.7"
 mockitoKotlin = "5.4.0"
 navigation = "2.8.0-alpha13"
 buildkonfig = "0.15.2"
+supabase = "3.1.4"
+ktor = "3.1.2"
 
 
 [libraries]
@@ -52,6 +54,11 @@ sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", versio
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
+supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
+ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }
+ktor-client-java = { module = "io.ktor:ktor-client-java", version.ref = "ktor" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }


### PR DESCRIPTION
## Summary
- Added supabase-kt 3.1.4 (pinned to Kotlin 2.1.x — 3.2.0+ uses Kotlin 2.2.x which breaks the build)
- ktor 3.1.2 engines: okhttp (Android), darwin (iOS), java (Desktop)
- `SupabaseClientProvider` initialises the client from `BuildKonfig.SUPABASE_URL` / `SUPABASE_ANON_KEY` — no runtime switching needed
- `AuthRepository` interface: signUp, signIn, signOut, currentUserId, isSignedIn
- `SupabaseAuthRepository` backed by Supabase Auth — session persistence handled by the SDK
- `supabaseModule` wired into Koin, loaded before `databaseModule`
- Credentials stored in `local.properties` (gitignored), read by BuildKonfig at compile time

## Test plan
- [ ] `./gradlew desktopTest` passes
- [ ] `./gradlew detekt` passes
- [ ] `./gradlew :composeApp:assembleDevDebug` builds without error