### PR TITLE
Add user session and auth screen

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -1,20 +1,27 @@
 package org.weekendware.basil
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.auth.AuthScreen
 import org.weekendware.basil.presentation.chat.ChatScreen
 import org.weekendware.basil.presentation.components.BasilBottomBar
 import org.weekendware.basil.presentation.components.BasilTopAppBar
 import org.weekendware.basil.presentation.dashboard.DashboardScreen
 import org.weekendware.basil.presentation.profile.ProfileScreen
+import org.weekendware.basil.presentation.session.SessionState
+import org.weekendware.basil.presentation.session.SessionViewModel
 import org.weekendware.basil.presentation.settings.SettingsScreen
 import org.weekendware.basil.presentation.theme.BasilTheme
 
@@ -27,44 +34,71 @@ val tabRoutes = setOf(ROUTE_HOME, ROUTE_PROFILE, ROUTE_CHAT)
 /**
  * Root composable for the Basil application.
  *
- * Sets up the top-level navigation structure using Compose Multiplatform Navigation:
- * - A [NavHost] manages all destinations: Home, Profile, Chat, and Settings.
- * - A [Scaffold] wraps the content with [BasilTopAppBar] and [BasilBottomBar].
- *   The bottom bar is hidden on the Settings screen.
+ * Observes [SessionViewModel] to decide which graph to display:
+ * - [SessionState.Loading]         — blank surface while the SDK restores a stored session.
+ * - [SessionState.Unauthenticated] — [AuthScreen] only; no scaffold, no back stack.
+ * - [SessionState.Authenticated]   — full app scaffold with [NavHost].
  *
- * All UI is wrapped in [BasilTheme] so every composable in the tree has access
- * to the Basil color, typography, shape, and spacing tokens.
+ * Auth and main-app navigation are kept in separate sub-trees so the
+ * back stack can never return to the sign-in screen from inside the app.
  */
 @Composable
 fun App() {
     BasilTheme {
-        val navController = rememberNavController()
-        val backStackEntry by navController.currentBackStackEntryAsState()
-        val currentRoute = backStackEntry?.destination?.route
+        val sessionViewModel = koinViewModel<SessionViewModel>()
+        val sessionState by sessionViewModel.state.collectAsState()
 
-        Scaffold(
-            topBar = {
-                BasilTopAppBar(
+        when (sessionState) {
+            SessionState.Loading -> {
+                // Blank surface — avoids flashing auth or app UI while the SDK
+                // resolves the stored session on cold start.
+                Box(modifier = Modifier.fillMaxSize())
+            }
+
+            SessionState.Unauthenticated -> {
+                AuthScreen()
+            }
+
+            SessionState.Authenticated -> {
+                MainApp()
+            }
+        }
+    }
+}
+
+/**
+ * The main application scaffold, shown only when the user is authenticated.
+ *
+ * Contains the [NavHost] for all primary destinations and the top/bottom bars.
+ */
+@Composable
+private fun MainApp() {
+    val navController = rememberNavController()
+    val backStackEntry by navController.currentBackStackEntryAsState()
+    val currentRoute = backStackEntry?.destination?.route
+
+    Scaffold(
+        topBar = {
+            BasilTopAppBar(
+                navController = navController,
+                currentRoute = currentRoute
+            )
+        },
+        bottomBar = {
+            if (currentRoute in tabRoutes) {
+                BasilBottomBar(
                     navController = navController,
                     currentRoute = currentRoute
                 )
-            },
-            bottomBar = {
-                if (currentRoute in tabRoutes) {
-                    BasilBottomBar(
-                        navController = navController,
-                        currentRoute = currentRoute
-                    )
-                }
             }
-        ) { innerPadding ->
-            Surface(modifier = Modifier.padding(innerPadding)) {
-                NavHost(navController = navController, startDestination = ROUTE_HOME) {
-                    composable(ROUTE_HOME)     { DashboardScreen() }
-                    composable(ROUTE_PROFILE)  { ProfileScreen() }
-                    composable(ROUTE_CHAT)     { ChatScreen() }
-                    composable(ROUTE_SETTINGS) { SettingsScreen() }
-                }
+        }
+    ) { innerPadding ->
+        Surface(modifier = Modifier.padding(innerPadding)) {
+            NavHost(navController = navController, startDestination = ROUTE_HOME) {
+                composable(ROUTE_HOME)     { DashboardScreen() }
+                composable(ROUTE_PROFILE)  { ProfileScreen() }
+                composable(ROUTE_CHAT)     { ChatScreen() }
+                composable(ROUTE_SETTINGS) { SettingsScreen() }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
@@ -1,12 +1,21 @@
 package org.weekendware.basil.data.repository
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * Contract for authentication operations.
  *
  * All methods return [Result] so callers can handle errors without
- * catching exceptions directly.
+ * catching exceptions directly. [sessionFlow] emits whenever the
+ * sign-in state changes so the UI layer can react without polling.
  */
 interface AuthRepository {
+
+    /**
+     * Emits `true` when a valid session exists, `false` when signed out.
+     * Replays the current state immediately on collection.
+     */
+    val sessionFlow: Flow<Boolean>
 
     /** Signs up a new user with [email] and [password]. */
     suspend fun signUp(email: String, password: String): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -1,8 +1,12 @@
 package org.weekendware.basil.data.repository
 
 import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.auth.auth
 import io.github.jan.supabase.auth.providers.builtin.Email
+import io.github.jan.supabase.auth.status.SessionStatus
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
 
 /**
  * [AuthRepository] implementation backed by Supabase Auth.
@@ -10,10 +14,16 @@ import io.github.jan.supabase.auth.providers.builtin.Email
  * Session persistence is handled automatically by the supabase-kt Auth
  * plugin — tokens are stored in platform-native secure storage and
  * restored on the next app launch.
+ *
+ * [sessionFlow] maps [Auth.sessionStatus] to a plain `Boolean` so the
+ * rest of the app has no direct dependency on supabase-kt types.
  */
 class SupabaseAuthRepository(
     private val client: SupabaseClient
 ) : AuthRepository {
+
+    override val sessionFlow: Flow<Boolean> =
+        client.auth.sessionStatus.map { it is SessionStatus.Authenticated }
 
     override suspend fun signUp(email: String, password: String): Result<Unit> =
         runCatching {

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -19,10 +19,12 @@ import org.weekendware.basil.domain.usecase.GetTodayEntriesUseCase
 import org.weekendware.basil.domain.usecase.ObserveRecentLogsUseCase
 import org.weekendware.basil.domain.usecase.SaveLogEntryUseCase
 import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
+import org.weekendware.basil.presentation.auth.AuthViewModel
 import org.weekendware.basil.presentation.chat.ChatViewModel
 import org.weekendware.basil.presentation.dashboard.DashboardViewModel
 import org.weekendware.basil.presentation.logging.LoggingViewModel
 import org.weekendware.basil.presentation.profile.ProfileViewModel
+import org.weekendware.basil.presentation.session.SessionViewModel
 import org.weekendware.basil.presentation.settings.SettingsViewModel
 
 /**
@@ -60,6 +62,8 @@ val useCaseModule = module {
  * Koin module that provides all shared ViewModels as singletons.
  */
 val sharedModule = module {
+    viewModel { SessionViewModel(get()) }
+    viewModel { AuthViewModel(get()) }
     viewModel { DashboardViewModel(get(), get(), get()) }
     viewModel { ProfileViewModel() }
     viewModel { ChatViewModel() }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
@@ -1,0 +1,127 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.theme.basilSpacing
+
+/**
+ * Authentication screen, shown when no valid session exists.
+ *
+ * Handles both sign-in and sign-up via a mode toggle. Navigation away
+ * from this screen happens automatically when [SessionViewModel] detects
+ * a successful authentication — this screen does not need to know about
+ * the nav graph.
+ */
+@Composable
+fun AuthScreen() {
+    val viewModel = koinViewModel<AuthViewModel>()
+    val state by viewModel.state.collectAsState()
+    val spacing = MaterialTheme.basilSpacing
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(spacing.xl),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = "Basil",
+            style = MaterialTheme.typography.displaySmall,
+            color = MaterialTheme.colorScheme.primary
+        )
+
+        Spacer(Modifier.height(spacing.xxxl))
+
+        Text(
+            text = if (state.isSignUp) "Create account" else "Sign in",
+            style = MaterialTheme.typography.headlineSmall
+        )
+
+        Spacer(Modifier.height(spacing.lg))
+
+        OutlinedTextField(
+            value = state.email,
+            onValueChange = viewModel::onEmailChange,
+            label = { Text("Email") },
+            singleLine = true,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Email,
+                imeAction = ImeAction.Next
+            ),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        Spacer(Modifier.height(spacing.md))
+
+        OutlinedTextField(
+            value = state.password,
+            onValueChange = viewModel::onPasswordChange,
+            label = { Text("Password") },
+            singleLine = true,
+            visualTransformation = PasswordVisualTransformation(),
+            keyboardOptions = KeyboardOptions(
+                keyboardType = KeyboardType.Password,
+                imeAction = ImeAction.Done
+            ),
+            keyboardActions = KeyboardActions(onDone = { viewModel.submit() }),
+            modifier = Modifier.fillMaxWidth()
+        )
+
+        state.error?.let { error ->
+            Spacer(Modifier.height(spacing.sm))
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+
+        Spacer(Modifier.height(spacing.lg))
+
+        if (state.isLoading) {
+            CircularProgressIndicator()
+        } else {
+            Button(
+                onClick = viewModel::submit,
+                enabled = state.canSubmit,
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text(if (state.isSignUp) "Create account" else "Sign in")
+            }
+        }
+
+        Spacer(Modifier.height(spacing.md))
+
+        TextButton(onClick = viewModel::toggleMode) {
+            val toggleLabel = if (state.isSignUp) {
+                "Already have an account? Sign in"
+            } else {
+                "No account? Create one"
+            }
+            Text(toggleLabel)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
@@ -1,0 +1,76 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.weekendware.basil.data.repository.AuthRepository
+
+/**
+ * Form state for the authentication screen.
+ *
+ * @property email        Current value of the email field.
+ * @property password     Current value of the password field.
+ * @property isSignUp     When true the form submits as sign-up; false = sign-in.
+ * @property isLoading    True while an auth network call is in flight.
+ * @property error        User-facing error message, or null when there is none.
+ */
+data class AuthFormState(
+    val email: String = "",
+    val password: String = "",
+    val isSignUp: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null
+) {
+    val canSubmit: Boolean get() = email.isNotBlank() && password.length >= 6 && !isLoading
+}
+
+/**
+ * ViewModel for [AuthScreen].
+ *
+ * Delegates credential operations to [AuthRepository] and surfaces
+ * results through [state]. Navigation after a successful auth is handled
+ * reactively by [SessionViewModel] — no explicit success callback is needed.
+ */
+class AuthViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(AuthFormState())
+
+    /** The current form state observed by [AuthScreen]. */
+    val state: StateFlow<AuthFormState> = _state
+
+    fun onEmailChange(value: String) = _state.update { it.copy(email = value, error = null) }
+    fun onPasswordChange(value: String) = _state.update { it.copy(password = value, error = null) }
+    fun toggleMode() = _state.update { it.copy(isSignUp = !it.isSignUp, error = null) }
+
+    /** Submits sign-in or sign-up depending on [AuthFormState.isSignUp]. */
+    fun submit() {
+        val current = _state.value
+        if (!current.canSubmit) return
+
+        _state.update { it.copy(isLoading = true, error = null) }
+
+        viewModelScope.launch {
+            val result = if (current.isSignUp) {
+                authRepository.signUp(current.email, current.password)
+            } else {
+                authRepository.signIn(current.email, current.password)
+            }
+
+            result.fold(
+                onSuccess = {
+                    // SessionViewModel will observe the auth state change and
+                    // navigate automatically — nothing to do here.
+                    _state.update { it.copy(isLoading = false) }
+                },
+                onFailure = { error ->
+                    _state.update { it.copy(isLoading = false, error = error.message ?: "Authentication failed") }
+                }
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
@@ -1,0 +1,47 @@
+package org.weekendware.basil.presentation.session
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import org.weekendware.basil.data.repository.AuthRepository
+
+/** Represents the resolved authentication state of the current session. */
+sealed interface SessionState {
+    /** Supabase is restoring the session from storage — do not navigate yet. */
+    data object Loading : SessionState
+
+    /** A valid session exists; the user is signed in. */
+    data object Authenticated : SessionState
+
+    /** No session — the user must sign in. */
+    data object Unauthenticated : SessionState
+}
+
+/**
+ * App-root ViewModel that owns the single source of truth for auth state.
+ *
+ * Collects [AuthRepository.sessionFlow] and exposes [state] as a
+ * [StateFlow] so [App] can decide which nav graph to display without
+ * any Supabase-specific types leaking into the UI layer.
+ *
+ * The initial value is [SessionState.Loading] to prevent a visible
+ * flash between the unauthenticated and authenticated screens while
+ * the SDK restores a stored session on cold start.
+ */
+class SessionViewModel(
+    authRepository: AuthRepository
+) : ViewModel() {
+
+    val state: StateFlow<SessionState> = authRepository.sessionFlow
+        .map { isSignedIn ->
+            if (isSignedIn) SessionState.Authenticated else SessionState.Unauthenticated
+        }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = SessionState.Loading
+        )
+}


### PR DESCRIPTION
## Summary
- `SessionState` sealed interface: `Loading`, `Authenticated`, `Unauthenticated`
- `SessionViewModel` collects `AuthRepository.sessionFlow` → `StateFlow<SessionState>`, initial value `Loading` to prevent cold-start flash
- `AuthRepository` extended with `sessionFlow: Flow<Boolean>`; `SupabaseAuthRepository` maps `client.auth.sessionStatus` to it
- `AuthViewModel` manages sign-in/sign-up form state; navigation after success is driven by `SessionViewModel` reacting to the Supabase session change — no manual nav call needed
- `AuthScreen` — email/password form with Sign In/Sign Up toggle, loading indicator, inline error
- `App` branches on session state: blank surface (loading), `AuthScreen` (unauthenticated), `MainApp` scaffold (authenticated). Auth and main-app nav graphs are separate sub-trees

## Test plan
- [ ] `./gradlew desktopTest` passes
- [ ] `./gradlew detekt` passes
- [ ] Cold start with no session shows sign-in screen
- [ ] Signing in navigates to dashboard automatically
- [ ] Signing out returns to sign-in screen