### PR TITLE
Add Sentry crash reporting

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -61,6 +61,7 @@ kotlin {
             implementation(libs.androidx.navigation.compose)
             implementation(libs.supabase.auth)
             implementation(libs.ktor.client.core)
+            implementation(libs.sentry.kmp)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)
@@ -159,6 +160,7 @@ buildkonfig {
         buildConfigField(STRING, "FLAVOR", "prod")
         buildConfigField(STRING, "SUPABASE_URL", localProps["supabase.prod.url"] as? String ?: "")
         buildConfigField(STRING, "SUPABASE_ANON_KEY", localProps["supabase.prod.anonKey"] as? String ?: "")
+        buildConfigField(STRING, "SENTRY_DSN", localProps["sentry.dsn"] as? String ?: "")
     }
     targetConfigs {
         create("dev") {

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -7,6 +7,7 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import org.koin.dsl.module
+import org.weekendware.basil.crash.initSentry
 import org.weekendware.basil.di.initKoin
 
 /**
@@ -24,6 +25,7 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        initSentry()
         initKoin {
             modules(module { single<android.content.Context> { applicationContext } })
         }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/crash/SentryService.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/crash/SentryService.kt
@@ -1,0 +1,23 @@
+package org.weekendware.basil.crash
+
+import io.sentry.kotlin.multiplatform.Sentry
+import org.weekendware.basil.BuildKonfig
+
+/**
+ * Initialises the Sentry SDK.
+ *
+ * Called once at app startup from each platform's entry point, before
+ * any user-facing UI is shown. DSN is injected from [BuildKonfig] at
+ * compile time so dev / staging / prod each report to the correct project.
+ *
+ * Crashes and unhandled exceptions are captured automatically by the SDK
+ * after this call. Use [Sentry.captureException] or [Sentry.captureMessage]
+ * for manual capture at known error boundaries.
+ */
+fun initSentry() {
+    Sentry.init { options ->
+        options.dsn = BuildKonfig.SENTRY_DSN
+        options.environment = BuildKonfig.FLAVOR
+        options.debug = BuildKonfig.FLAVOR == "dev"
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/org/weekendware/basil/main.kt
+++ b/composeApp/src/desktopMain/kotlin/org/weekendware/basil/main.kt
@@ -2,6 +2,7 @@ package org.weekendware.basil
 
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
+import org.weekendware.basil.crash.initSentry
 import org.weekendware.basil.di.initKoin
 
 /**
@@ -15,6 +16,7 @@ import org.weekendware.basil.di.initKoin
  * file-backed [JdbcSqliteDriver] before shipping a desktop release.
  */
 fun main() = application {
+    initSentry()
     initKoin()
     Window(
         onCloseRequest = ::exitApplication,

--- a/composeApp/src/iosMain/kotlin/org/weekendware/basil/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/org/weekendware/basil/MainViewController.kt
@@ -1,6 +1,7 @@
 package org.weekendware.basil
 
 import androidx.compose.ui.window.ComposeUIViewController
+import org.weekendware.basil.crash.initSentry
 import org.weekendware.basil.di.initKoin
 
 /**
@@ -18,6 +19,7 @@ import org.weekendware.basil.di.initKoin
  * @return A [UIViewController] rendering the full [App] composable.
  */
 fun MainViewController() = run {
+    initSentry()
     initKoin()
     ComposeUIViewController { App() }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ mockitoKotlin = "5.4.0"
 navigation = "2.8.0-alpha13"
 buildkonfig = "0.15.2"
 supabase = "3.1.4"
+sentry = "0.25.0"
 ktor = "3.1.2"
 
 
@@ -55,6 +56,7 @@ sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", 
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
+sentry-kmp = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentry" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }
 ktor-client-darwin = { module = "io.ktor:ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- `sentry-kotlin-multiplatform 0.25.0` — matches Kotlin 2.1.21, no stdlib conflicts
- `initSentry()` in commonMain reads `BuildKonfig.SENTRY_DSN` and `BuildKonfig.FLAVOR` — dev/staging/prod events are tagged separately in the Sentry dashboard
- Debug mode enabled automatically in the `dev` flavor
- DSN stored in `local.properties` (gitignored), injected into `BuildKonfig` at compile time — never in source
- Called before Koin and UI on all three platforms (Android `MainActivity`, iOS `MainViewController`, Desktop `main`)

## Test plan
- [ ] `./gradlew desktopTest` passes
- [ ] `./gradlew detekt` passes
- [ ] Run the app and force a crash — event appears in Sentry dashboard under `dev` environment