### PR TITLE
Fill test gaps for auth, session, and use cases

### DIFF
--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
@@ -1,0 +1,42 @@
+package org.weekendware.basil.data.repository
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * In-memory [AuthRepository] for tests.
+ *
+ * [signInResult] and [signUpResult] can be set before calling [signIn] /
+ * [signUp] to simulate success or failure. [setSignedIn] drives [sessionFlow]
+ * so [SessionViewModel] tests can verify state transitions.
+ */
+class FakeAuthRepository : AuthRepository {
+
+    private val _sessionFlow = MutableStateFlow(false)
+    override val sessionFlow: Flow<Boolean> = _sessionFlow
+
+    var signInResult: Result<Unit> = Result.success(Unit)
+    var signUpResult: Result<Unit> = Result.success(Unit)
+
+    fun setSignedIn(value: Boolean) {
+        _sessionFlow.value = value
+    }
+
+    override suspend fun signIn(email: String, password: String): Result<Unit> {
+        if (signInResult.isSuccess) _sessionFlow.value = true
+        return signInResult
+    }
+
+    override suspend fun signUp(email: String, password: String): Result<Unit> {
+        if (signUpResult.isSuccess) _sessionFlow.value = true
+        return signUpResult
+    }
+
+    override suspend fun signOut(): Result<Unit> {
+        _sessionFlow.value = false
+        return Result.success(Unit)
+    }
+
+    override fun currentUserId(): String? = if (_sessionFlow.value) "fake-uid" else null
+    override fun isSignedIn(): Boolean = _sessionFlow.value
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/DeleteLogEntryUseCaseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/DeleteLogEntryUseCaseTest.kt
@@ -1,0 +1,59 @@
+package org.weekendware.basil.domain.usecase
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.weekendware.basil.data.repository.SqlDelightLogRepository
+import org.weekendware.basil.database.BasilDatabase
+import org.weekendware.basil.domain.model.BgUnit
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class DeleteLogEntryUseCaseTest {
+
+    private lateinit var repository: SqlDelightLogRepository
+    private lateinit var saveUseCase: SaveLogEntryUseCase
+    private lateinit var deleteUseCase: DeleteLogEntryUseCase
+
+    @BeforeTest
+    fun setup() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BasilDatabase.Schema.create(driver)
+        repository = SqlDelightLogRepository(BasilDatabase(driver))
+        saveUseCase = SaveLogEntryUseCase(repository)
+        deleteUseCase = DeleteLogEntryUseCase(repository)
+    }
+
+    @Test
+    fun `deleting an entry removes it from the repository`() = runTest {
+        saveUseCase("5.5", BgUnit.MMOLL, "", "")
+        val entry = repository.getRecent(10).first().first()
+
+        val result = deleteUseCase(entry.id)
+
+        assertTrue(result.isSuccess)
+        assertTrue(repository.getRecent(10).first().isEmpty())
+    }
+
+    @Test
+    fun `deleting a non-existent id succeeds without error`() {
+        val result = deleteUseCase(id = 999L)
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `deleting one of multiple entries leaves the others intact`() = runTest {
+        saveUseCase("4.0", BgUnit.MMOLL, "", "")
+        saveUseCase("8.0", BgUnit.MMOLL, "", "")
+        val entries = repository.getRecent(10).first()
+        val toDelete = entries.first()
+
+        deleteUseCase(toDelete.id)
+
+        val remaining = repository.getRecent(10).first()
+        assertFalse(remaining.any { it.id == toDelete.id })
+        assertTrue(remaining.size == 1)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/ObserveRecentLogsUseCaseTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/domain/usecase/ObserveRecentLogsUseCaseTest.kt
@@ -1,0 +1,55 @@
+package org.weekendware.basil.domain.usecase
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.weekendware.basil.data.repository.SqlDelightLogRepository
+import org.weekendware.basil.database.BasilDatabase
+import org.weekendware.basil.domain.model.BgUnit
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ObserveRecentLogsUseCaseTest {
+
+    private lateinit var repository: SqlDelightLogRepository
+    private lateinit var saveUseCase: SaveLogEntryUseCase
+    private lateinit var observeUseCase: ObserveRecentLogsUseCase
+
+    @BeforeTest
+    fun setup() {
+        val driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+        BasilDatabase.Schema.create(driver)
+        repository = SqlDelightLogRepository(BasilDatabase(driver))
+        saveUseCase = SaveLogEntryUseCase(repository)
+        observeUseCase = ObserveRecentLogsUseCase(repository)
+    }
+
+    @Test
+    fun `emits empty list when no entries exist`() = runTest {
+        assertTrue(observeUseCase().first().isEmpty())
+    }
+
+    @Test
+    fun `emits saved entries`() = runTest {
+        saveUseCase("7.2", BgUnit.MMOLL, "4", "60")
+        val entries = observeUseCase().first()
+        assertEquals(1, entries.size)
+    }
+
+    @Test
+    fun `entries are ordered most recent first`() = runTest {
+        saveUseCase("4.0", BgUnit.MMOLL, "", "")
+        saveUseCase("9.0", BgUnit.MMOLL, "", "")
+        val entries = observeUseCase().first()
+        assertTrue(entries[0].timestamp >= entries[1].timestamp)
+    }
+
+    @Test
+    fun `respects the 100-entry limit`() = runTest {
+        repeat(105) { saveUseCase("5.0", BgUnit.MMOLL, "", "") }
+        val entries = observeUseCase().first()
+        assertEquals(100, entries.size)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
@@ -1,0 +1,106 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class AuthViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+    private lateinit var viewModel: AuthViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+        viewModel = AuthViewModel(repo)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is empty sign-in form`() {
+        val state = viewModel.state.value
+        assertEquals("", state.email)
+        assertEquals("", state.password)
+        assertFalse(state.isSignUp)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `canSubmit is false when email is blank`() {
+        viewModel.onPasswordChange("password123")
+        assertFalse(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `canSubmit is false when password is shorter than 6 characters`() {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("abc")
+        assertFalse(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `canSubmit is true when email and password meet requirements`() {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("password123")
+        assertTrue(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `toggleMode switches between sign-in and sign-up`() {
+        assertFalse(viewModel.state.value.isSignUp)
+        viewModel.toggleMode()
+        assertTrue(viewModel.state.value.isSignUp)
+        viewModel.toggleMode()
+        assertFalse(viewModel.state.value.isSignUp)
+    }
+
+    @Test
+    fun `successful sign-in clears loading and error`() = runTest {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("password123")
+        viewModel.submit()
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `failed sign-in surfaces error message`() = runTest {
+        repo.signInResult = Result.failure(Exception("Invalid credentials"))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("password123")
+        viewModel.submit()
+        assertNotNull(viewModel.state.value.error)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun `onEmailChange clears existing error`() = runTest {
+        repo.signInResult = Result.failure(Exception("error"))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("password123")
+        viewModel.submit()
+        viewModel.onEmailChange("new@test.com")
+        assertNull(viewModel.state.value.error)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
@@ -1,0 +1,59 @@
+package org.weekendware.basil.presentation.session
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SessionViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+    private lateinit var viewModel: SessionViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+        viewModel = SessionViewModel(repo)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is Unauthenticated when no session exists`() = runTest {
+        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `state becomes Authenticated when session flow emits true`() = runTest {
+        repo.setSignedIn(true)
+        assertEquals(SessionState.Authenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `state returns to Unauthenticated when session is cleared`() = runTest {
+        repo.setSignedIn(true)
+        repo.setSignedIn(false)
+        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `state reflects sign-out after sign-in`() = runTest {
+        repo.setSignedIn(true)
+        assertEquals(SessionState.Authenticated, viewModel.state.value)
+        repo.signOut()
+        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+    }
+}


### PR DESCRIPTION
## Summary
- `FakeAuthRepository` — controllable in-memory fake; drives both `AuthViewModel` and `SessionViewModel` tests without network
- `AuthViewModelTest` — 8 tests: initial state, canSubmit validation, mode toggle, success/failure paths, error clearing
- `SessionViewModelTest` — 4 tests: initial unauthenticated state, sign-in → Authenticated, sign-out → Unauthenticated, round-trip
- `DeleteLogEntryUseCaseTest` — 3 tests: delete removes entry, non-existent ID is a no-op, only target entry is removed
- `ObserveRecentLogsUseCaseTest` — 4 tests: empty state, saved entries appear, ordering, 100-entry limit

25 tests total, all passing.

## Test plan
- [ ] `./gradlew desktopTest` passes (25 tests)
- [ ] `./gradlew detekt` passes