### PR TITLE
Add profile screen with BG target editing

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -41,6 +41,22 @@
     <string name="nav_profile">Profile</string>
     <string name="nav_chat">Basil</string>
 
+    <!-- ── Profile screen ──────────────────────────────────── -->
+    <string name="profile_section_account">Account</string>
+    <string name="profile_section_health">Health Profile</string>
+    <string name="profile_label_name">Name</string>
+    <string name="profile_label_email">Email</string>
+    <string name="profile_label_target_range">Target BG Range</string>
+    <string name="profile_label_target_low">Low</string>
+    <string name="profile_label_target_high">High</string>
+    <string name="profile_placeholder_name">Your name</string>
+    <string name="profile_placeholder_target">0</string>
+    <string name="profile_action_edit">Edit</string>
+    <string name="profile_action_save">Save</string>
+    <string name="profile_action_cancel">Cancel</string>
+    <string name="profile_no_user">No profile data found</string>
+    <string name="error_profile_save_failed">Failed to save profile. Please try again.</string>
+
     <!-- ── Screens ───────────────────────────────────────────── -->
     <string name="screen_settings">Settings</string>
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PreferencesRepository.kt
@@ -23,4 +23,26 @@ interface PreferencesRepository {
      * @param unit The [BgUnit] to store.
      */
     fun setBgUnit(unit: BgUnit)
+
+    /**
+     * Returns the user's low end of their target BG range, in their preferred unit.
+     * Defaults to 3.9 mmol/L equivalent; callers should interpret in context of the current unit.
+     */
+    fun getBgTargetLow(): Double
+
+    /**
+     * Persists the user's low BG target.
+     */
+    fun setBgTargetLow(value: Double)
+
+    /**
+     * Returns the user's high end of their target BG range.
+     * Defaults to 10.0 mmol/L equivalent.
+     */
+    fun getBgTargetHigh(): Double
+
+    /**
+     * Persists the user's high BG target.
+     */
+    fun setBgTargetHigh(value: Double)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightPreferencesRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightPreferencesRepository.kt
@@ -14,8 +14,12 @@ import org.weekendware.basil.domain.model.BgUnit
 class SqlDelightPreferencesRepository(private val database: BasilDatabase) : PreferencesRepository {
 
     companion object {
-        /** Key for the user's preferred blood glucose unit. */
-        private const val BG_UNIT_KEY = "bg_unit"
+        private const val BG_UNIT_KEY        = "bg_unit"
+        private const val BG_TARGET_LOW_KEY  = "bg_target_low"
+        private const val BG_TARGET_HIGH_KEY = "bg_target_high"
+
+        private const val DEFAULT_TARGET_LOW  = 3.9
+        private const val DEFAULT_TARGET_HIGH = 10.0
     }
 
     override fun getBgUnit(): BgUnit {
@@ -25,5 +29,21 @@ class SqlDelightPreferencesRepository(private val database: BasilDatabase) : Pre
 
     override fun setBgUnit(unit: BgUnit) {
         database.preferencesQueries.set(BG_UNIT_KEY, unit.name)
+    }
+
+    override fun getBgTargetLow(): Double =
+        database.preferencesQueries.get(BG_TARGET_LOW_KEY).executeAsOneOrNull()
+            ?.toDoubleOrNull() ?: DEFAULT_TARGET_LOW
+
+    override fun setBgTargetLow(value: Double) {
+        database.preferencesQueries.set(BG_TARGET_LOW_KEY, value.toString())
+    }
+
+    override fun getBgTargetHigh(): Double =
+        database.preferencesQueries.get(BG_TARGET_HIGH_KEY).executeAsOneOrNull()
+            ?.toDoubleOrNull() ?: DEFAULT_TARGET_HIGH
+
+    override fun setBgTargetHigh(value: Double) {
+        database.preferencesQueries.set(BG_TARGET_HIGH_KEY, value.toString())
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -13,11 +13,14 @@ import org.weekendware.basil.data.repository.SqlDelightUserRepository
 import org.weekendware.basil.data.repository.SupabaseAuthRepository
 import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.DeleteLogEntryUseCase
+import org.weekendware.basil.domain.usecase.GetBgTargetsUseCase
 import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
 import org.weekendware.basil.domain.usecase.GetLastBgReadingUseCase
 import org.weekendware.basil.domain.usecase.GetTodayEntriesUseCase
+import org.weekendware.basil.domain.usecase.GetUserUseCase
 import org.weekendware.basil.domain.usecase.ObserveRecentLogsUseCase
 import org.weekendware.basil.domain.usecase.SaveLogEntryUseCase
+import org.weekendware.basil.domain.usecase.SetBgTargetsUseCase
 import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
 import org.weekendware.basil.presentation.auth.AuthViewModel
 import org.weekendware.basil.presentation.chat.ChatViewModel
@@ -56,6 +59,9 @@ val useCaseModule = module {
     single { DeleteLogEntryUseCase(get()) }
     single { GetBgUnitPreferenceUseCase(get()) }
     single { SetBgUnitPreferenceUseCase(get()) }
+    single { GetUserUseCase(get()) }
+    single { GetBgTargetsUseCase(get()) }
+    single { SetBgTargetsUseCase(get()) }
 }
 
 /**
@@ -65,7 +71,7 @@ val sharedModule = module {
     viewModel { SessionViewModel(get()) }
     viewModel { AuthViewModel(get()) }
     viewModel { DashboardViewModel(get(), get(), get()) }
-    viewModel { ProfileViewModel() }
+    viewModel { ProfileViewModel(get(), get(), get()) }
     viewModel { ChatViewModel() }
     viewModel { SettingsViewModel() }
     viewModel { LoggingViewModel(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetBgTargetsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetBgTargetsUseCase.kt
@@ -1,0 +1,17 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.PreferencesRepository
+
+/**
+ * Returns the user's persisted target BG range as a [BgTargets] pair.
+ *
+ * @param preferencesRepository Source of truth for user preferences.
+ */
+class GetBgTargetsUseCase(private val preferencesRepository: PreferencesRepository) {
+    operator fun invoke(): BgTargets = BgTargets(
+        low  = preferencesRepository.getBgTargetLow(),
+        high = preferencesRepository.getBgTargetHigh()
+    )
+}
+
+data class BgTargets(val low: Double, val high: Double)

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetUserUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/GetUserUseCase.kt
@@ -1,0 +1,13 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.UserRepository
+import org.weekendware.basil.domain.model.User
+
+/**
+ * Returns the current user, or null if no user has been stored locally yet.
+ *
+ * @param userRepository Source of truth for user data.
+ */
+class GetUserUseCase(private val userRepository: UserRepository) {
+    operator fun invoke(): User? = userRepository.getAll().firstOrNull()
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SetBgTargetsUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SetBgTargetsUseCase.kt
@@ -1,0 +1,15 @@
+package org.weekendware.basil.domain.usecase
+
+import org.weekendware.basil.data.repository.PreferencesRepository
+
+/**
+ * Persists the user's target BG range.
+ *
+ * @param preferencesRepository Destination for user preferences.
+ */
+class SetBgTargetsUseCase(private val preferencesRepository: PreferencesRepository) {
+    operator fun invoke(low: Double, high: Double) {
+        preferencesRepository.setBgTargetLow(low)
+        preferencesRepository.setBgTargetHigh(high)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -1,23 +1,344 @@
 package org.weekendware.basil.presentation.profile
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.profile_action_cancel
+import basil.composeapp.generated.resources.profile_action_edit
+import basil.composeapp.generated.resources.profile_action_save
+import basil.composeapp.generated.resources.profile_label_email
+import basil.composeapp.generated.resources.profile_label_name
+import basil.composeapp.generated.resources.profile_label_target_high
+import basil.composeapp.generated.resources.profile_label_target_low
+import basil.composeapp.generated.resources.profile_label_target_range
+import basil.composeapp.generated.resources.profile_placeholder_name
+import basil.composeapp.generated.resources.profile_placeholder_target
+import basil.composeapp.generated.resources.profile_section_account
+import basil.composeapp.generated.resources.profile_section_health
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.theme.BasilTheme
+import org.weekendware.basil.presentation.theme.basilSpacing
 
 /**
- * The user Profile screen.
- *
- * Currently a placeholder. This screen will allow the user to configure
- * their health profile, including:
- * - Diabetes type and diagnosis date
- * - Insulin type(s) and typical doses
- * - Target blood glucose range
- * - Personal preferences (units, notification settings)
+ * Profile screen — shows account info and the user's target BG range.
+ * Entering edit mode allows updating targets; name is shown read-only
+ * until full user-update support is wired to Supabase.
  */
 @Composable
 fun ProfileScreen() {
     val viewModel = koinViewModel<ProfileViewModel>()
-    val title = viewModel.title.collectAsState()
-    Text(title.value)
+    val state by viewModel.state.collectAsState()
+    ProfileScreenContent(
+        state           = state,
+        onEditClick     = viewModel::onEditClick,
+        onCancelClick   = viewModel::onCancelClick,
+        onNameChange    = viewModel::onNameChange,
+        onTargetLowChange  = viewModel::onTargetLowChange,
+        onTargetHighChange = viewModel::onTargetHighChange,
+        onSaveClick     = viewModel::onSaveClick
+    )
+}
+
+@Composable
+fun ProfileScreenContent(
+    state: ProfileState,
+    onEditClick: () -> Unit,
+    onCancelClick: () -> Unit,
+    onNameChange: (String) -> Unit,
+    onTargetLowChange: (String) -> Unit,
+    onTargetHighChange: (String) -> Unit,
+    onSaveClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spacing = MaterialTheme.basilSpacing
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = spacing.lg, vertical = spacing.xl),
+        verticalArrangement = Arrangement.spacedBy(spacing.xl)
+    ) {
+        // ── Avatar + name header ──────────────────────────────
+        ProfileHeader(name = state.name, email = state.email)
+
+        // ── Account section ───────────────────────────────────
+        ProfileSection(title = stringResource(Res.string.profile_section_account)) {
+            ProfileReadOnlyRow(
+                label = stringResource(Res.string.profile_label_name),
+                value = state.name.ifBlank { stringResource(Res.string.profile_placeholder_name) }
+            )
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            ProfileReadOnlyRow(
+                label = stringResource(Res.string.profile_label_email),
+                value = state.email
+            )
+        }
+
+        // ── Health profile section ────────────────────────────
+        ProfileSection(title = stringResource(Res.string.profile_section_health)) {
+            Text(
+                text  = stringResource(Res.string.profile_label_target_range),
+                style = MaterialTheme.typography.labelLarge,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+            Spacer(Modifier.height(spacing.sm))
+
+            if (state.isEditing) {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.md),
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    OutlinedTextField(
+                        value         = state.targetBgLow,
+                        onValueChange = onTargetLowChange,
+                        label         = { Text(stringResource(Res.string.profile_label_target_low)) },
+                        placeholder   = { Text(stringResource(Res.string.profile_placeholder_target)) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        singleLine    = true,
+                        modifier      = Modifier.weight(1f)
+                    )
+                    OutlinedTextField(
+                        value         = state.targetBgHigh,
+                        onValueChange = onTargetHighChange,
+                        label         = { Text(stringResource(Res.string.profile_label_target_high)) },
+                        placeholder   = { Text(stringResource(Res.string.profile_placeholder_target)) },
+                        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Decimal),
+                        singleLine    = true,
+                        modifier      = Modifier.weight(1f)
+                    )
+                }
+            } else {
+                Row(
+                    horizontalArrangement = Arrangement.spacedBy(spacing.xs),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        text  = state.targetBgLow,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text  = "–",
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                    Text(
+                        text  = state.targetBgHigh,
+                        style = MaterialTheme.typography.bodyLarge,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                }
+            }
+
+            // Error
+            state.error?.let { err ->
+                Spacer(Modifier.height(spacing.xs))
+                Text(
+                    text  = stringResource(err),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        // ── Actions ───────────────────────────────────────────
+        if (state.isEditing) {
+            Row(
+                horizontalArrangement = Arrangement.spacedBy(spacing.md),
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                OutlinedButton(
+                    onClick  = onCancelClick,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(Res.string.profile_action_cancel).uppercase())
+                }
+                Button(
+                    onClick  = onSaveClick,
+                    modifier = Modifier.weight(1f)
+                ) {
+                    Text(stringResource(Res.string.profile_action_save).uppercase())
+                }
+            }
+        } else {
+            TextButton(
+                onClick  = onEditClick,
+                modifier = Modifier.align(Alignment.End)
+            ) {
+                Text(stringResource(Res.string.profile_action_edit).uppercase())
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sub-composables
+// ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun ProfileHeader(name: String, email: String) {
+    Column(
+        modifier            = Modifier.fillMaxWidth(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(MaterialTheme.basilSpacing.sm)
+    ) {
+        // Initials avatar
+        Surface(
+            modifier  = Modifier.size(72.dp).clip(CircleShape),
+            color     = MaterialTheme.colorScheme.primaryContainer
+        ) {
+            Text(
+                text      = name.initials(),
+                modifier  = Modifier.fillMaxSize().padding(top = 18.dp),
+                textAlign = TextAlign.Center,
+                style     = MaterialTheme.typography.headlineMedium,
+                color     = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+        }
+
+        if (name.isNotBlank()) {
+            Text(
+                text  = name,
+                style = MaterialTheme.typography.titleLarge,
+                color = MaterialTheme.colorScheme.onBackground
+            )
+        }
+        if (email.isNotBlank()) {
+            Text(
+                text  = email,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+    }
+}
+
+@Composable
+private fun ProfileSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val spacing = MaterialTheme.basilSpacing
+    ElevatedCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier            = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
+        ) {
+            Text(
+                text  = title.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun ProfileReadOnlyRow(label: String, value: String) {
+    Row(
+        modifier              = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.SpaceBetween,
+        verticalAlignment     = Alignment.CenterVertically
+    ) {
+        Text(
+            text  = label,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant
+        )
+        Text(
+            text  = value,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+    }
+}
+
+private fun String.initials(): String =
+    trim().split(" ")
+        .filter { it.isNotBlank() }
+        .take(2)
+        .joinToString("") { it.first().uppercaseChar().toString() }
+        .ifBlank { "?" }
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun ProfileScreenContentPreview() {
+    BasilTheme {
+        ProfileScreenContent(
+            state = ProfileState(
+                name         = "Gavin Dunne",
+                email        = "gavin@weekendware.io",
+                targetBgLow  = "3.9",
+                targetBgHigh = "10.0",
+                isEditing    = false
+            ),
+            onEditClick        = {},
+            onCancelClick      = {},
+            onNameChange       = {},
+            onTargetLowChange  = {},
+            onTargetHighChange = {},
+            onSaveClick        = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ProfileScreenEditingPreview() {
+    BasilTheme {
+        ProfileScreenContent(
+            state = ProfileState(
+                name         = "Gavin Dunne",
+                email        = "gavin@weekendware.io",
+                targetBgLow  = "4.0",
+                targetBgHigh = "9.0",
+                isEditing    = true
+            ),
+            onEditClick        = {},
+            onCancelClick      = {},
+            onNameChange       = {},
+            onTargetLowChange  = {},
+            onTargetHighChange = {},
+            onSaveClick        = {}
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
@@ -1,20 +1,103 @@
 package org.weekendware.basil.presentation.profile
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_profile_save_failed
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.domain.usecase.GetBgTargetsUseCase
+import org.weekendware.basil.domain.usecase.GetUserUseCase
+import org.weekendware.basil.domain.usecase.SetBgTargetsUseCase
 
 /**
  * ViewModel for [ProfileScreen].
  *
- * Currently a placeholder. As the profile feature is implemented, this
- * ViewModel will expose and manage the user's health profile data,
- * loading it from the database via a `UserRepository` and coordinating
- * saves when the user edits their profile.
+ * Loads the current user and their BG targets on init, and exposes
+ * an edit/save flow for updating targets and display name.
  */
-class ProfileViewModel : ViewModel() {
-    private val _title = MutableStateFlow("Profile")
+class ProfileViewModel(
+    private val getUser: GetUserUseCase,
+    private val getBgTargets: GetBgTargetsUseCase,
+    private val setBgTargets: SetBgTargetsUseCase
+) : ViewModel() {
 
-    /** The screen title, used as a placeholder until the profile UI is built. */
-    val title: StateFlow<String> = _title
+    private val _state = MutableStateFlow(ProfileState())
+    val state: StateFlow<ProfileState> = _state.asStateFlow()
+
+    init {
+        load()
+    }
+
+    private fun load() {
+        val user    = getUser()
+        val targets = getBgTargets()
+        _state.update {
+            it.copy(
+                name         = user?.name ?: "",
+                email        = user?.email ?: "",
+                targetBgLow  = formatTarget(targets.low),
+                targetBgHigh = formatTarget(targets.high)
+            )
+        }
+    }
+
+    fun onEditClick() {
+        _state.update { it.copy(isEditing = true, error = null) }
+    }
+
+    fun onCancelClick() {
+        load()
+        _state.update { it.copy(isEditing = false, error = null) }
+    }
+
+    fun onNameChange(value: String) {
+        _state.update { it.copy(name = value) }
+    }
+
+    fun onTargetLowChange(value: String) {
+        _state.update { it.copy(targetBgLow = value) }
+    }
+
+    fun onTargetHighChange(value: String) {
+        _state.update { it.copy(targetBgHigh = value) }
+    }
+
+    fun onSaveClick() {
+        val s = _state.value
+        val low  = s.targetBgLow.toDoubleOrNull()
+        val high = s.targetBgHigh.toDoubleOrNull()
+
+        if (low == null || high == null || low >= high) {
+            _state.update { it.copy(error = Res.string.error_profile_save_failed) }
+            return
+        }
+
+        runCatching { setBgTargets(low, high) }
+            .onSuccess { _state.update { it.copy(isEditing = false, error = null) } }
+            .onFailure { _state.update { it.copy(error = Res.string.error_profile_save_failed) } }
+    }
+
+    fun clearError() {
+        _state.update { it.copy(error = null) }
+    }
+
+    // ── Helpers ───────────────────────────────────────────────
+
+    private fun formatTarget(value: Double): String =
+        if (value == value.toLong().toDouble()) value.toLong().toString()
+        else value.toString()
 }
+
+@Immutable
+data class ProfileState(
+    val name: String          = "",
+    val email: String         = "",
+    val targetBgLow: String   = "",
+    val targetBgHigh: String  = "",
+    val isEditing: Boolean    = false,
+    val error: StringResource? = null
+)

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -1,0 +1,180 @@
+package org.weekendware.basil.presentation.profile
+
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_profile_save_failed
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.weekendware.basil.data.repository.PreferencesRepository
+import org.weekendware.basil.data.repository.UserRepository
+import org.weekendware.basil.domain.model.User
+import org.weekendware.basil.domain.usecase.GetBgTargetsUseCase
+import org.weekendware.basil.domain.usecase.GetUserUseCase
+import org.weekendware.basil.domain.usecase.SetBgTargetsUseCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ProfileViewModelTest {
+
+    private val userRepository        = mock<UserRepository>()
+    private val preferencesRepository = mock<PreferencesRepository>()
+
+    private val getUser       = GetUserUseCase(userRepository)
+    private val getBgTargets  = GetBgTargetsUseCase(preferencesRepository)
+    private val setBgTargets  = SetBgTargetsUseCase(preferencesRepository)
+
+    private fun makeVm(
+        name: String  = "Test User",
+        email: String = "test@example.com",
+        low: Double   = 3.9,
+        high: Double  = 10.0
+    ): ProfileViewModel {
+        whenever(userRepository.getAll()).thenReturn(listOf(User("1", name, email)))
+        whenever(preferencesRepository.getBgTargetLow()).thenReturn(low)
+        whenever(preferencesRepository.getBgTargetHigh()).thenReturn(high)
+        return ProfileViewModel(getUser, getBgTargets, setBgTargets)
+    }
+
+    // ── initial load ──────────────────────────────────────────
+
+    @Test
+    fun `loads name and email from user repository`() {
+        val vm = makeVm(name = "Gavin Dunne", email = "gavin@weekendware.io")
+
+        assertEquals("Gavin Dunne", vm.state.value.name)
+        assertEquals("gavin@weekendware.io", vm.state.value.email)
+    }
+
+    @Test
+    fun `loads target BG range from preferences`() {
+        val vm = makeVm(low = 4.0, high = 9.0)
+
+        // Whole numbers are formatted without decimal (4.0 → "4", 9.0 → "9")
+        assertEquals("4", vm.state.value.targetBgLow)
+        assertEquals("9", vm.state.value.targetBgHigh)
+    }
+
+    @Test
+    fun `name and email are empty when no user exists`() {
+        whenever(userRepository.getAll()).thenReturn(emptyList())
+        whenever(preferencesRepository.getBgTargetLow()).thenReturn(3.9)
+        whenever(preferencesRepository.getBgTargetHigh()).thenReturn(10.0)
+        val vm = ProfileViewModel(getUser, getBgTargets, setBgTargets)
+
+        assertEquals("", vm.state.value.name)
+        assertEquals("", vm.state.value.email)
+    }
+
+    @Test
+    fun `isEditing starts false`() {
+        val vm = makeVm()
+        assertFalse(vm.state.value.isEditing)
+    }
+
+    // ── edit / cancel ─────────────────────────────────────────
+
+    @Test
+    fun `onEditClick sets isEditing to true`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        assertTrue(vm.state.value.isEditing)
+    }
+
+    @Test
+    fun `onCancelClick sets isEditing to false and reloads data`() {
+        val vm = makeVm(low = 3.9, high = 10.0)
+        vm.onEditClick()
+        vm.onTargetLowChange("1.0")
+        vm.onCancelClick()
+
+        assertFalse(vm.state.value.isEditing)
+        assertEquals("3.9", vm.state.value.targetBgLow)
+    }
+
+    // ── field changes ─────────────────────────────────────────
+
+    @Test
+    fun `onTargetLowChange updates targetBgLow in state`() {
+        val vm = makeVm()
+        vm.onTargetLowChange("4.5")
+        assertEquals("4.5", vm.state.value.targetBgLow)
+    }
+
+    @Test
+    fun `onTargetHighChange updates targetBgHigh in state`() {
+        val vm = makeVm()
+        vm.onTargetHighChange("11.0")
+        assertEquals("11.0", vm.state.value.targetBgHigh)
+    }
+
+    // ── save ──────────────────────────────────────────────────
+
+    @Test
+    fun `onSaveClick persists targets and exits edit mode on success`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        vm.onTargetLowChange("4.0")
+        vm.onTargetHighChange("9.0")
+        vm.onSaveClick()
+
+        verify(preferencesRepository).setBgTargetLow(4.0)
+        verify(preferencesRepository).setBgTargetHigh(9.0)
+        assertFalse(vm.state.value.isEditing)
+        assertNull(vm.state.value.error)
+    }
+
+    @Test
+    fun `onSaveClick sets error when low is not a valid number`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        vm.onTargetLowChange("abc")
+        vm.onTargetHighChange("10.0")
+        vm.onSaveClick()
+
+        assertEquals(Res.string.error_profile_save_failed, vm.state.value.error)
+        assertTrue(vm.state.value.isEditing)
+    }
+
+    @Test
+    fun `onSaveClick sets error when low is greater than or equal to high`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        vm.onTargetLowChange("10.0")
+        vm.onTargetHighChange("4.0")
+        vm.onSaveClick()
+
+        assertEquals(Res.string.error_profile_save_failed, vm.state.value.error)
+    }
+
+    @Test
+    fun `onSaveClick sets error when repository throws`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        vm.onTargetLowChange("4.0")
+        vm.onTargetHighChange("9.0")
+        doThrow(RuntimeException("DB error")).whenever(preferencesRepository).setBgTargetLow(4.0)
+
+        vm.onSaveClick()
+
+        assertEquals(Res.string.error_profile_save_failed, vm.state.value.error)
+    }
+
+    // ── clearError ────────────────────────────────────────────
+
+    @Test
+    fun `clearError removes error from state`() {
+        val vm = makeVm()
+        vm.onEditClick()
+        vm.onTargetLowChange("abc")
+        vm.onSaveClick()
+        assertEquals(Res.string.error_profile_save_failed, vm.state.value.error)
+
+        vm.clearError()
+
+        assertNull(vm.state.value.error)
+    }
+}


### PR DESCRIPTION
## Summary

- Full profile screen: initials avatar, account section (name + email read-only), health profile section (target BG range editable)
- Adds `GetUserUseCase`, `GetBgTargetsUseCase`, `SetBgTargetsUseCase`
- Extends `PreferencesRepository` with `getBgTargetLow/High` and `setBgTargetLow/High` persisted to SQLDelight
- Content-composable split (`ProfileScreen` + `ProfileScreenContent`) with two `@Preview` variants
- `ProfileViewModelTest` — 13 tests, all green

## Test plan

- [ ] All 13 `ProfileViewModelTest` tests pass (`./gradlew desktopTest`)
- [ ] Profile tab shows name, email, and target BG range on a signed-in account
- [ ] Edit button enters edit mode with input fields for low/high targets
- [ ] Save persists values; Cancel reverts without saving
- [ ] Error shown when low ≥ high or non-numeric input