### PR TITLE
Add settings screen with BG unit toggle

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -57,6 +57,16 @@
     <string name="profile_no_user">No profile data found</string>
     <string name="error_profile_save_failed">Failed to save profile. Please try again.</string>
 
+    <!-- ── Settings screen ──────────────────────────────────── -->
+    <string name="settings_section_data">Data</string>
+    <string name="settings_section_notifications">Notifications</string>
+    <string name="settings_section_about">About</string>
+    <string name="settings_label_bg_unit">Blood Glucose Unit</string>
+    <string name="settings_label_reminders">Log reminders</string>
+    <string name="settings_label_reminders_hint">Remind me to log at set times</string>
+    <string name="settings_label_version">Version</string>
+    <string name="settings_notifications_coming_soon">Notification settings coming soon</string>
+
     <!-- ── Screens ───────────────────────────────────────────── -->
     <string name="screen_settings">Settings</string>
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -73,6 +73,6 @@ val sharedModule = module {
     viewModel { DashboardViewModel(get(), get(), get()) }
     viewModel { ProfileViewModel(get(), get(), get()) }
     viewModel { ChatViewModel() }
-    viewModel { SettingsViewModel() }
+    viewModel { SettingsViewModel(get(), get()) }
     viewModel { LoggingViewModel(get(), get(), get()) }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
@@ -1,37 +1,227 @@
 package org.weekendware.basil.presentation.settings
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ElevatedCard
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.settings_label_bg_unit
+import basil.composeapp.generated.resources.settings_label_reminders
+import basil.composeapp.generated.resources.settings_label_reminders_hint
+import basil.composeapp.generated.resources.settings_label_version
+import basil.composeapp.generated.resources.settings_notifications_coming_soon
+import basil.composeapp.generated.resources.settings_section_about
+import basil.composeapp.generated.resources.settings_section_data
+import basil.composeapp.generated.resources.settings_section_notifications
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
-import org.weekendware.basil.presentation.theme.basilColors
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.basilSpacing
 
 /**
- * The Settings screen, accessible from the top app bar gear icon.
- *
- * Currently a placeholder surface. As settings are defined (units, notifications,
- * theme preference, profile data, etc.) they will be added here as grouped
- * preference rows.
+ * Settings screen — BG unit selection, notifications placeholder, and app info.
  */
 @Composable
 fun SettingsScreen() {
     val viewModel = koinViewModel<SettingsViewModel>()
-    val title = viewModel.title.collectAsState()
+    val state by viewModel.state.collectAsState()
+    SettingsScreenContent(
+        state          = state,
+        onBgUnitChange = viewModel::onBgUnitChange
+    )
+}
 
-    Surface(
-        modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.basilColors.surfaceVariant
+@Composable
+fun SettingsScreenContent(
+    state: SettingsState,
+    onBgUnitChange: (BgUnit) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val spacing = MaterialTheme.basilSpacing
+
+    Column(
+        modifier = modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = spacing.lg, vertical = spacing.xl),
+        verticalArrangement = Arrangement.spacedBy(spacing.xl)
     ) {
-        Text(
-            text     = title.value,
-            modifier = Modifier.padding(MaterialTheme.basilSpacing.xl),
-            style    = MaterialTheme.typography.headlineMedium
+        // ── Data ──────────────────────────────────────────────
+        SettingsSection(title = stringResource(Res.string.settings_section_data)) {
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                Text(
+                    text  = stringResource(Res.string.settings_label_bg_unit),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                BgUnitToggle(
+                    selected       = state.bgUnit,
+                    onUnitSelected = onBgUnitChange
+                )
+            }
+
+            state.error?.let { err ->
+                Text(
+                    text  = stringResource(err),
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+
+        // ── Notifications ─────────────────────────────────────
+        SettingsSection(title = stringResource(Res.string.settings_section_notifications)) {
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                Column(modifier = Modifier.weight(1f)) {
+                    Text(
+                        text  = stringResource(Res.string.settings_label_reminders),
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurface
+                    )
+                    Text(
+                        text  = stringResource(Res.string.settings_label_reminders_hint),
+                        style = MaterialTheme.typography.bodySmall,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
+                Switch(
+                    checked         = false,
+                    onCheckedChange = null,
+                    enabled         = false
+                )
+            }
+            Text(
+                text  = stringResource(Res.string.settings_notifications_coming_soon),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant
+            )
+        }
+
+        // ── About ─────────────────────────────────────────────
+        SettingsSection(title = stringResource(Res.string.settings_section_about)) {
+            HorizontalDivider(color = MaterialTheme.colorScheme.outlineVariant)
+            Row(
+                modifier              = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.SpaceBetween,
+                verticalAlignment     = Alignment.CenterVertically
+            ) {
+                Text(
+                    text  = stringResource(Res.string.settings_label_version),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+                Text(
+                    text  = "1.0.0",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Sub-composables
+// ─────────────────────────────────────────────────────────────
+
+@Composable
+private fun SettingsSection(
+    title: String,
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val spacing = MaterialTheme.basilSpacing
+    ElevatedCard(modifier = modifier.fillMaxWidth()) {
+        Column(
+            modifier            = Modifier.padding(spacing.xl),
+            verticalArrangement = Arrangement.spacedBy(spacing.md)
+        ) {
+            Text(
+                text  = title.uppercase(),
+                style = MaterialTheme.typography.labelSmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            content()
+        }
+    }
+}
+
+@Composable
+private fun BgUnitToggle(
+    selected: BgUnit,
+    onUnitSelected: (BgUnit) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.spacedBy(MaterialTheme.basilSpacing.xs)) {
+        BgUnit.entries.forEach { unit ->
+            if (unit == selected) {
+                Button(
+                    onClick  = {},
+                    enabled  = false,
+                    colors   = ButtonDefaults.buttonColors(
+                        disabledContainerColor = MaterialTheme.colorScheme.primary,
+                        disabledContentColor   = MaterialTheme.colorScheme.onPrimary
+                    )
+                ) { Text(unit.label) }
+            } else {
+                OutlinedButton(onClick = { onUnitSelected(unit) }) {
+                    Text(unit.label)
+                }
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun SettingsScreenMgdlPreview() {
+    BasilTheme {
+        SettingsScreenContent(
+            state          = SettingsState(bgUnit = BgUnit.MGDL),
+            onBgUnitChange = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun SettingsScreenMmollPreview() {
+    BasilTheme {
+        SettingsScreenContent(
+            state          = SettingsState(bgUnit = BgUnit.MMOLL),
+            onBgUnitChange = {}
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModel.kt
@@ -1,20 +1,45 @@
 package org.weekendware.basil.presentation.settings
 
+import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_save_preference_failed
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
+import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
 
 /**
  * ViewModel for [SettingsScreen].
  *
- * Currently a placeholder. As settings options are implemented (BG unit,
- * notification preferences, theme selection, etc.) this ViewModel will
- * expose state flows for each setting and coordinate persistence via
- * [PreferencesRepository].
+ * Manages app-level preferences: BG unit selection (persisted) and
+ * notification settings placeholder.
  */
-class SettingsViewModel : ViewModel() {
-    private val _title = MutableStateFlow("Settings")
+class SettingsViewModel(
+    private val getBgUnit: GetBgUnitPreferenceUseCase,
+    private val setBgUnit: SetBgUnitPreferenceUseCase
+) : ViewModel() {
 
-    /** The screen title, displayed in the top app bar. */
-    val title: StateFlow<String> = _title
+    private val _state = MutableStateFlow(SettingsState(bgUnit = getBgUnit()))
+    val state: StateFlow<SettingsState> = _state.asStateFlow()
+
+    fun onBgUnitChange(unit: BgUnit) {
+        setBgUnit(unit)
+            .onSuccess { _state.update { it.copy(bgUnit = unit, error = null) } }
+            .onFailure { _state.update { it.copy(error = Res.string.error_save_preference_failed) } }
+    }
+
+    fun clearError() {
+        _state.update { it.copy(error = null) }
+    }
 }
+
+@Immutable
+data class SettingsState(
+    val bgUnit: BgUnit         = BgUnit.MGDL,
+    val error: StringResource? = null
+)

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/settings/SettingsViewModelTest.kt
@@ -1,0 +1,91 @@
+package org.weekendware.basil.presentation.settings
+
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_save_preference_failed
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.weekendware.basil.data.repository.PreferencesRepository
+import org.weekendware.basil.domain.model.BgUnit
+import org.weekendware.basil.domain.usecase.GetBgUnitPreferenceUseCase
+import org.weekendware.basil.domain.usecase.SetBgUnitPreferenceUseCase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class SettingsViewModelTest {
+
+    private val preferencesRepository = mock<PreferencesRepository>()
+    private val getBgUnitPreference = GetBgUnitPreferenceUseCase(preferencesRepository)
+    private val setBgUnitPreference = SetBgUnitPreferenceUseCase(preferencesRepository)
+
+    private fun makeVm(unit: BgUnit = BgUnit.MGDL): SettingsViewModel {
+        whenever(preferencesRepository.getBgUnit()).thenReturn(unit)
+        return SettingsViewModel(getBgUnitPreference, setBgUnitPreference)
+    }
+
+    // ── initial state ─────────────────────────────────────────
+
+    @Test
+    fun `initial bgUnit is loaded from preferences`() {
+        val vm = makeVm(BgUnit.MMOLL)
+        assertEquals(BgUnit.MMOLL, vm.state.value.bgUnit)
+    }
+
+    @Test
+    fun `initial error is null`() {
+        val vm = makeVm()
+        assertNull(vm.state.value.error)
+    }
+
+    // ── BG unit change ────────────────────────────────────────
+
+    @Test
+    fun `onBgUnitChange updates bgUnit in state`() {
+        val vm = makeVm(BgUnit.MGDL)
+        vm.onBgUnitChange(BgUnit.MMOLL)
+        assertEquals(BgUnit.MMOLL, vm.state.value.bgUnit)
+    }
+
+    @Test
+    fun `onBgUnitChange persists unit to preferences`() {
+        val vm = makeVm()
+        vm.onBgUnitChange(BgUnit.MMOLL)
+        verify(preferencesRepository).setBgUnit(BgUnit.MMOLL)
+    }
+
+    @Test
+    fun `onBgUnitChange sets error when preference write fails`() {
+        val vm = makeVm()
+        doThrow(RuntimeException("DB error")).whenever(preferencesRepository).setBgUnit(BgUnit.MMOLL)
+
+        vm.onBgUnitChange(BgUnit.MMOLL)
+
+        assertEquals(Res.string.error_save_preference_failed, vm.state.value.error)
+    }
+
+    @Test
+    fun `onBgUnitChange does not update bgUnit in state when write fails`() {
+        val vm = makeVm(BgUnit.MGDL)
+        doThrow(RuntimeException("DB error")).whenever(preferencesRepository).setBgUnit(BgUnit.MMOLL)
+
+        vm.onBgUnitChange(BgUnit.MMOLL)
+
+        assertEquals(BgUnit.MGDL, vm.state.value.bgUnit)
+    }
+
+    // ── clearError ────────────────────────────────────────────
+
+    @Test
+    fun `clearError removes error from state`() {
+        val vm = makeVm()
+        doThrow(RuntimeException("DB error")).whenever(preferencesRepository).setBgUnit(BgUnit.MMOLL)
+        vm.onBgUnitChange(BgUnit.MMOLL)
+        assertEquals(Res.string.error_save_preference_failed, vm.state.value.error)
+
+        vm.clearError()
+
+        assertNull(vm.state.value.error)
+    }
+}


### PR DESCRIPTION
## Summary

- Full settings screen: BG unit toggle (mg/dL / mmol/L), notifications placeholder with coming-soon copy, version info
- `SettingsViewModel` wired to `GetBgUnitPreferenceUseCase` and `SetBgUnitPreferenceUseCase` via `Result` pattern
- Content-composable split with two `@Preview` variants (mg/dL and mmol/L selected)
- `SettingsViewModelTest` written test-first — uncovered that `SetBgUnitPreferenceUseCase` wraps exceptions in `Result<Unit>`, requiring `.onFailure` not `try/catch`
- 7 tests, all green; full suite 107/107 passing

## Test plan

- [ ] All 107 tests pass (`./gradlew desktopTest`)
- [ ] Settings screen accessible from gear icon in top bar
- [ ] BG unit toggle switches between mg/dL and mmol/L and persists across app restarts
- [ ] Notifications section shows disabled toggle with coming-soon message
- [ ] Version row shows 1.0.0