### PR TITLE
Add CLAUDE.md and fix Koin double-init crash

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# Basil — Claude Code Rules
+
+## Git workflow
+- Branch from `develop`, never from `main`
+- Branch naming: `MMDDYYYY-description` (e.g. `05222026-android-fix`) — date first so branches sort chronologically
+- PRs always target `develop` — pass `--base develop` explicitly with `gh pr create`
+- `main` is production-only; only merged from `develop` at release time
+- No co-author lines, no AI attribution in commit messages
+
+## Development standards
+- TDD: write tests before or alongside implementation
+- All ViewModels accept `coroutineScope: CoroutineScope? = null` for testability (defaults to `viewModelScope`)
+- String resources in `strings.xml` — no hardcoded strings in composables
+- Errors surfaces as `StringResource` on state, never raw exception messages
+- `basilSpacing` is accessed via `MaterialTheme.basilSpacing.X` inside composables
+
+## Android
+- Koin and Sentry init live in `BasilApplication.onCreate`, never in `MainActivity.onCreate`
+  (putting them in Activity causes `KoinApplicationAlreadyStartedException` on recreation)
+- Run with Java 21: `JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home`
+  (Java 26 is installed but breaks the Kotlin compiler in this Gradle version)
+- Install and launch: `./gradlew installDevDebug` then `adb shell am start -n org.weekendware.basil.dev/org.weekendware.basil.MainActivity`
+
+## Architecture
+- KMP targets: Android, iOS Simulator (Arm64), Desktop (JVM)
+- DI: Koin — `chatModule`, `supabaseModule`, `databaseModule`, `useCaseModule`, `sharedModule`, `platformModule`
+- Database: SQLDelight
+- Build flavors: `dev` / `staging` / `prod` (via BuildKonfig)
+- Navigation: sealed `AppRoute` class, `NavHost` with 3-tab bottom nav + Settings stack
+
+## HIPAA
+- HTTPS guard in `KtorChatRepository` is exempt for `dev` flavor (localhost testing)
+- Chat history is cleared on sign-out via `LaunchedEffect` in `App.kt`
+- Never log request/response bodies — they may contain PHI
+
+## companion repo
+- `basil-chat-api` lives at `~/Desktop/Projects/basil-chat-api` (Rust/Axum)
+- Follows identical branching, TDD, and commit standards
+- Needs `.env` with `ANTHROPIC_API_KEY`, `API_KEY`, `PORT=8080` to run locally
+- Start locally: `~/.cargo/bin/cargo run`
+- `local.properties` in basil: `chat.api.url=http://localhost:8080`, `chat.api.key=<matches API_KEY in .env>`

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -2,6 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application
+        android:name=".BasilApplication"
         android:allowBackup="true"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/BasilApplication.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/BasilApplication.kt
@@ -1,0 +1,30 @@
+package org.weekendware.basil
+
+import android.app.Application
+import android.content.Context
+import org.koin.dsl.module
+import org.weekendware.basil.crash.initSentry
+import org.weekendware.basil.di.initKoin
+
+/**
+ * Custom [Application] that initialises process-scoped singletons exactly once.
+ *
+ * Moving Koin and Sentry init here (rather than [MainActivity.onCreate]) prevents
+ * [org.koin.core.error.KoinApplicationAlreadyStartedException] on activity
+ * recreation (rotation, multi-window, etc.), because [Application.onCreate] is
+ * only called once per process lifetime.
+ */
+class BasilApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+
+        initSentry()
+
+        initKoin {
+            // Register applicationContext so DatabaseDriverFactory can receive
+            // it via get<Context>() in the platform module.
+            modules(module { single<Context> { applicationContext } })
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -10,11 +10,8 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import org.koin.dsl.module
 import org.koin.mp.KoinPlatform
-import org.weekendware.basil.crash.initSentry
 import org.weekendware.basil.data.repository.AuthRepository
-import org.weekendware.basil.di.initKoin
 
 /**
  * The single Android [ComponentActivity] that hosts the entire Basil UI.
@@ -24,9 +21,11 @@ import org.weekendware.basil.di.initKoin
  *   SDK has resolved the stored session. This covers the cold-start window
  *   before the first Compose frame is drawn.
  * - Enables edge-to-edge display so content draws behind system bars.
- * - Initialises Koin, passing `applicationContext` so [DatabaseDriverFactory]
- *   can receive it via `get<Context>()`.
  * - Sets the Compose content root to [App].
+ *
+ * Koin and Sentry initialisation live in [BasilApplication.onCreate] so they
+ * survive activity recreation (rotation, multi-window, etc.) without throwing
+ * [org.koin.core.error.KoinApplicationAlreadyStartedException].
  */
 class MainActivity : ComponentActivity() {
 
@@ -34,11 +33,6 @@ class MainActivity : ComponentActivity() {
         val splashScreen = installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        initSentry()
-        initKoin {
-            modules(module { single<android.content.Context> { applicationContext } })
-        }
 
         // Keep the OS splash visible until sessionFlow emits its first value.
         // The first emission means Supabase has finished restoring (or not) the


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` with branching rules, dev standards, Android gotchas, HIPAA notes, and companion repo setup — loaded automatically by Claude Code at the start of every session
- Fixes `KoinApplicationAlreadyStartedException` crash on activity recreation by moving `initKoin` and `initSentry` from `MainActivity.onCreate` into a new `BasilApplication` class registered in `AndroidManifest.xml`

## Test plan
- [ ] Launch app, rotate device/emulator — no crash
- [ ] Cold start works as before (splash, session restore, correct screen)