### PR TITLE
Profile picture support

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,10 +62,14 @@ kotlin {
             implementation(libs.koin.compose.viewmodel)
             implementation(libs.androidx.navigation.compose)
             implementation(libs.supabase.auth)
+            implementation(libs.supabase.storage)
             implementation(libs.ktor.client.core)
             implementation(libs.ktor.client.content.negotiation)
             implementation(libs.ktor.serialization.kotlinx.json)
             implementation(libs.sentry.kmp)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor)
+            implementation(libs.calf.file.picker)
         }
         commonTest.dependencies {
             implementation(libs.kotlin.test)

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -56,6 +56,10 @@
     <string name="profile_action_cancel">Cancel</string>
     <string name="profile_no_user">No profile data found</string>
     <string name="error_profile_save_failed">Failed to save profile. Please try again.</string>
+    <string name="profile_pick_photo">Change photo</string>
+    <string name="profile_remove_photo">Remove photo</string>
+    <string name="cd_profile_avatar">Profile picture</string>
+    <string name="error_avatar_upload_failed">Failed to update photo. Please try again.</string>
 
     <!-- ── Settings screen ──────────────────────────────────── -->
     <string name="settings_section_data">Data</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/remote/SupabaseClientProvider.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/remote/SupabaseClientProvider.kt
@@ -3,6 +3,7 @@ package org.weekendware.basil.data.remote
 import io.github.jan.supabase.SupabaseClient
 import io.github.jan.supabase.auth.Auth
 import io.github.jan.supabase.createSupabaseClient
+import io.github.jan.supabase.storage.Storage
 import org.weekendware.basil.BuildKonfig
 
 /**
@@ -17,4 +18,5 @@ fun createSupabaseClient(): SupabaseClient = createSupabaseClient(
     supabaseKey = BuildKonfig.SUPABASE_ANON_KEY
 ) {
     install(Auth)
+    install(Storage)
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AvatarRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AvatarRepository.kt
@@ -1,0 +1,30 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Contract for profile picture storage.
+ *
+ * Uploads and removes avatar images for a given user. The storage
+ * backend is abstracted so callers (ViewModels) are not coupled to
+ * Supabase directly.
+ */
+interface AvatarRepository {
+
+    /**
+     * Uploads [imageBytes] as the avatar for [userId] and returns the
+     * public URL of the stored image.
+     *
+     * Calling this when an avatar already exists replaces it (upsert).
+     *
+     * @param userId    The authenticated user's ID — used as the storage path.
+     * @param imageBytes Raw image data (JPEG or PNG).
+     * @return A [Result] containing the public URL on success.
+     */
+    suspend fun uploadAvatar(userId: String, imageBytes: ByteArray): Result<String>
+
+    /**
+     * Deletes the avatar for [userId] from remote storage.
+     *
+     * @return A [Result] indicating success or failure.
+     */
+    suspend fun deleteAvatar(userId: String): Result<Unit>
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/KtorChatRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/KtorChatRepository.kt
@@ -70,11 +70,13 @@ class KtorChatRepository(private val httpClient: HttpClient) : ChatRepository {
      */
     override fun streamChat(messages: List<ChatMessage>): Flow<String> = flow {
         // HTTPS-only guard: PHI must never travel over an unencrypted channel.
-        // This will catch misconfigured `local.properties` before any data leaves
-        // the device. An http:// URL in production is a critical configuration error.
-        require(BuildKonfig.CHAT_API_URL.startsWith("https://")) {
-            "CHAT_API_URL must use HTTPS to protect PHI in transit. " +
-            "Got: ${BuildKonfig.CHAT_API_URL}"
+        // The dev flavor is exempt so localhost testing works without TLS.
+        // Staging and prod will fail fast here if misconfigured.
+        if (BuildKonfig.FLAVOR != "dev") {
+            require(BuildKonfig.CHAT_API_URL.startsWith("https://")) {
+                "CHAT_API_URL must use HTTPS to protect PHI in transit. " +
+                "Got: ${BuildKonfig.CHAT_API_URL}"
+            }
         }
 
         // Context window cap: send only the most recent messages to limit the

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -20,9 +20,17 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
     override fun insert(id: String, name: String, email: String) =
         database.userQueries.insertUser(id, name, email)
 
+    override fun updateAvatarUrl(userId: String, url: String?) =
+        database.userQueries.updateAvatarUrl(url, userId)
+
     override fun deleteAll() = database.userQueries.deleteAll()
 
     // ── Mapping ───────────────────────────────────────────────
 
-    private fun UserEntity.toDomain() = User(id = id, name = name, email = email)
+    private fun UserEntity.toDomain() = User(
+        id = id,
+        name = name,
+        email = email,
+        avatarUrl = avatar_url,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAvatarRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAvatarRepository.kt
@@ -1,0 +1,39 @@
+package org.weekendware.basil.data.repository
+
+import io.github.jan.supabase.SupabaseClient
+import io.github.jan.supabase.storage.storage
+
+/**
+ * [AvatarRepository] backed by Supabase Storage.
+ *
+ * Avatars are stored in the `avatars` bucket under the path `{userId}/avatar`.
+ * The bucket must be configured as **public** in the Supabase dashboard so
+ * [publicUrl] returns a usable image URL without signed-URL expiry.
+ *
+ * @param client The shared [SupabaseClient] with the Storage plugin installed.
+ */
+class SupabaseAvatarRepository(private val client: SupabaseClient) : AvatarRepository {
+
+    private val bucket = "avatars"
+
+    /**
+     * Uploads [imageBytes] to `avatars/{userId}/avatar`, replacing any
+     * existing file. Returns the public URL of the uploaded image.
+     */
+    override suspend fun uploadAvatar(userId: String, imageBytes: ByteArray): Result<String> =
+        runCatching {
+            val path = avatarPath(userId)
+            client.storage.from(bucket).upload(path, imageBytes) { upsert = true }
+            client.storage.from(bucket).publicUrl(path)
+        }
+
+    /**
+     * Removes the avatar at `avatars/{userId}/avatar` from remote storage.
+     */
+    override suspend fun deleteAvatar(userId: String): Result<Unit> =
+        runCatching {
+            client.storage.from(bucket).delete(avatarPath(userId))
+        }
+
+    private fun avatarPath(userId: String) = "$userId/avatar"
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/UserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/UserRepository.kt
@@ -25,6 +25,11 @@ interface UserRepository {
     fun insert(id: String, name: String, email: String)
 
     /**
+     * Persists the avatar URL for [userId]. Pass null to clear the avatar.
+     */
+    fun updateAvatarUrl(userId: String, url: String?)
+
+    /**
      * Deletes all user records. Used during development and reset flows.
      *
      * **Caution:** This is destructive and permanent.

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -9,6 +9,7 @@ import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 import org.weekendware.basil.data.repository.AuthRepository
+import org.weekendware.basil.data.repository.AvatarRepository
 import org.weekendware.basil.data.repository.ChatRepository
 import org.weekendware.basil.data.repository.KtorChatRepository
 import org.weekendware.basil.data.repository.LogRepository
@@ -17,6 +18,7 @@ import org.weekendware.basil.data.repository.SqlDelightLogRepository
 import org.weekendware.basil.data.repository.SqlDelightPreferencesRepository
 import org.weekendware.basil.data.repository.SqlDelightUserRepository
 import org.weekendware.basil.data.repository.SupabaseAuthRepository
+import org.weekendware.basil.data.repository.SupabaseAvatarRepository
 import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.DeleteLogEntryUseCase
 import org.weekendware.basil.domain.usecase.SendMessageUseCase
@@ -60,6 +62,7 @@ val chatModule = module {
 val supabaseModule = module {
     single { createSupabaseClient() }
     single<AuthRepository> { SupabaseAuthRepository(get()) }
+    single<AvatarRepository> { SupabaseAvatarRepository(get()) }
 }
 
 /**
@@ -96,7 +99,7 @@ val sharedModule = module {
     viewModel { SessionViewModel(get()) }
     viewModel { AuthViewModel(get()) }
     viewModel { DashboardViewModel(get(), get(), get()) }
-    viewModel { ProfileViewModel(get(), get(), get()) }
+    viewModel { ProfileViewModel(get(), get(), get(), get(), get()) }
     viewModel { ChatViewModel(get()) }
     viewModel { SettingsViewModel(get(), get()) }
     viewModel { LoggingViewModel(get(), get(), get()) }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/model/User.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/model/User.kt
@@ -3,12 +3,15 @@ package org.weekendware.basil.domain.model
 /**
  * Represents a Basil user account.
  *
- * @property id    Unique identifier (UUID string).
- * @property name  The user's display name.
- * @property email The user's email address.
+ * @property id        Unique identifier (UUID string).
+ * @property name      The user's display name.
+ * @property email     The user's email address.
+ * @property avatarUrl Public URL of the user's profile picture in Supabase
+ *                     Storage, or null if no photo has been set.
  */
 data class User(
-    val id:    String,
-    val name:  String,
-    val email: String
+    val id: String,
+    val name: String,
+    val email: String,
+    val avatarUrl: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -1,5 +1,6 @@
 package org.weekendware.basil.presentation.profile
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -23,8 +24,6 @@ import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -38,6 +37,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
@@ -115,12 +115,13 @@ fun ProfileScreenContent(
     ) {
         // ── Avatar + name header ──────────────────────────────
         ProfileHeader(
-            name             = state.name,
-            email            = state.email,
-            avatarUrl        = state.avatarUrl,
-            isUploading      = state.isUploadingAvatar,
-            onAvatarPicked   = onAvatarPicked,
-            onRemoveAvatar   = onRemoveAvatar
+            name               = state.name,
+            email              = state.email,
+            avatarUrl          = state.avatarUrl,
+            pendingAvatarBytes = state.pendingAvatarBytes,
+            isUploading        = state.isUploadingAvatar,
+            onAvatarPicked     = onAvatarPicked,
+            onRemoveAvatar     = onRemoveAvatar
         )
 
         // ── Account section ───────────────────────────────────
@@ -237,11 +238,14 @@ fun ProfileScreenContent(
 // Sub-composables
 // ─────────────────────────────────────────────────────────────
 
+private val AvatarSize = 96.dp
+
 @Composable
 private fun ProfileHeader(
     name: String,
     email: String,
     avatarUrl: String?,
+    pendingAvatarBytes: ByteArray?,
     isUploading: Boolean,
     onAvatarPicked: (ByteArray) -> Unit,
     onRemoveAvatar: () -> Unit
@@ -266,66 +270,85 @@ private fun ProfileHeader(
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.spacedBy(spacing.sm)
     ) {
-        // Avatar with overlay controls
-        Box(contentAlignment = Alignment.BottomEnd) {
-            if (avatarUrl != null) {
-                AsyncImage(
-                    model             = avatarUrl,
+        // ── Avatar circle — entire circle is the tap target ──
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier
+                .size(AvatarSize)
+                .clip(CircleShape)
+                .clickable(enabled = !isUploading) { pickerLauncher.launch() }
+        ) {
+            // Image layer: pending bytes take priority over the remote URL
+            when {
+                pendingAvatarBytes != null -> AsyncImage(
+                    model              = pendingAvatarBytes,
                     contentDescription = stringResource(Res.string.cd_profile_avatar),
-                    contentScale      = ContentScale.Crop,
-                    modifier          = Modifier.size(72.dp).clip(CircleShape)
+                    contentScale       = ContentScale.Crop,
+                    modifier           = Modifier.fillMaxSize()
                 )
-            } else {
-                Surface(
-                    modifier  = Modifier.size(72.dp).clip(CircleShape),
-                    color     = MaterialTheme.colorScheme.primaryContainer
+                avatarUrl != null -> AsyncImage(
+                    model              = avatarUrl,
+                    contentDescription = stringResource(Res.string.cd_profile_avatar),
+                    contentScale       = ContentScale.Crop,
+                    modifier           = Modifier.fillMaxSize()
+                )
+                else -> Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color    = MaterialTheme.colorScheme.primaryContainer
                 ) {
-                    if (isUploading) {
-                        CircularProgressIndicator(
-                            modifier  = Modifier.padding(16.dp),
-                            color     = MaterialTheme.colorScheme.onPrimaryContainer,
-                            strokeWidth = 2.dp
-                        )
-                    } else {
-                        Text(
-                            text      = name.initials(),
-                            modifier  = Modifier.fillMaxSize().padding(top = 18.dp),
-                            textAlign = TextAlign.Center,
-                            style     = MaterialTheme.typography.headlineMedium,
-                            color     = MaterialTheme.colorScheme.onPrimaryContainer
-                        )
-                    }
+                    Text(
+                        text      = name.initials(),
+                        modifier  = Modifier.fillMaxSize().padding(top = 24.dp),
+                        textAlign = TextAlign.Center,
+                        style     = MaterialTheme.typography.headlineLarge,
+                        color     = MaterialTheme.colorScheme.onPrimaryContainer
+                    )
                 }
             }
 
-            // Camera button (bottom-end of avatar)
+            // Semi-transparent bottom scrim with camera icon
             if (!isUploading) {
-                IconButton(
-                    onClick = { pickerLauncher.launch() },
-                    modifier = Modifier.size(28.dp),
-                    colors = IconButtonDefaults.iconButtonColors(
-                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
-                        contentColor   = MaterialTheme.colorScheme.onSecondaryContainer
-                    )
+                Box(
+                    contentAlignment = Alignment.Center,
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .height(AvatarSize * 0.35f)
+                        .align(Alignment.BottomCenter)
                 ) {
+                    Surface(
+                        modifier = Modifier.fillMaxSize(),
+                        color    = Color.Black.copy(alpha = 0.45f)
+                    ) {}
                     Icon(
                         imageVector        = Icons.Default.AddAPhoto,
-                        contentDescription = stringResource(Res.string.profile_pick_photo),
-                        modifier           = Modifier.size(16.dp)
+                        contentDescription = null,
+                        tint               = Color.White,
+                        modifier           = Modifier.size(20.dp)
                     )
                 }
+            }
+
+            // Upload spinner overlay
+            if (isUploading) {
+                Surface(
+                    modifier = Modifier.fillMaxSize(),
+                    color    = Color.Black.copy(alpha = 0.45f)
+                ) {}
+                CircularProgressIndicator(
+                    modifier    = Modifier.size(32.dp),
+                    color       = Color.White,
+                    strokeWidth = 2.5.dp
+                )
             }
         }
 
-        // Remove photo button — only shown when an avatar exists
-        if (avatarUrl != null && !isUploading) {
-            TextButton(
-                onClick = onRemoveAvatar
-            ) {
+        // Remove photo — only when an image exists and not uploading
+        if ((pendingAvatarBytes != null || avatarUrl != null) && !isUploading) {
+            TextButton(onClick = onRemoveAvatar) {
                 Icon(
                     imageVector        = Icons.Default.Close,
                     contentDescription = null,
-                    modifier           = Modifier.size(16.dp)
+                    modifier           = Modifier.size(14.dp)
                 )
                 Spacer(Modifier.size(spacing.xs))
                 Text(
@@ -423,8 +446,8 @@ internal fun ProfileScreenContentPreview() {
             onTargetLowChange  = {},
             onTargetHighChange = {},
             onSaveClick        = {},
-            onAvatarPicked     = {},
-            onRemoveAvatar     = {}
+            onAvatarPicked = {},
+            onRemoveAvatar = {}
         )
     }
 }
@@ -447,8 +470,8 @@ internal fun ProfileScreenEditingPreview() {
             onTargetLowChange  = {},
             onTargetHighChange = {},
             onSaveClick        = {},
-            onAvatarPicked     = {},
-            onRemoveAvatar     = {}
+            onAvatarPicked = {},
+            onRemoveAvatar = {}
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -1,6 +1,7 @@
 package org.weekendware.basil.presentation.profile
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
@@ -14,9 +15,16 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddAPhoto
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
@@ -26,13 +34,16 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.cd_profile_avatar
 import basil.composeapp.generated.resources.profile_action_cancel
 import basil.composeapp.generated.resources.profile_action_edit
 import basil.composeapp.generated.resources.profile_action_save
@@ -41,10 +52,19 @@ import basil.composeapp.generated.resources.profile_label_name
 import basil.composeapp.generated.resources.profile_label_target_high
 import basil.composeapp.generated.resources.profile_label_target_low
 import basil.composeapp.generated.resources.profile_label_target_range
+import basil.composeapp.generated.resources.profile_pick_photo
 import basil.composeapp.generated.resources.profile_placeholder_name
 import basil.composeapp.generated.resources.profile_placeholder_target
+import basil.composeapp.generated.resources.profile_remove_photo
 import basil.composeapp.generated.resources.profile_section_account
 import basil.composeapp.generated.resources.profile_section_health
+import coil3.compose.AsyncImage
+import com.mohamedrejeb.calf.core.LocalPlatformContext
+import com.mohamedrejeb.calf.io.readByteArray
+import com.mohamedrejeb.calf.picker.FilePickerFileType
+import com.mohamedrejeb.calf.picker.FilePickerSelectionMode
+import com.mohamedrejeb.calf.picker.rememberFilePickerLauncher
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -52,22 +72,22 @@ import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.basilSpacing
 
 /**
- * Profile screen — shows account info and the user's target BG range.
- * Entering edit mode allows updating targets; name is shown read-only
- * until full user-update support is wired to Supabase.
+ * Profile screen — shows account info, avatar, and the user's target BG range.
  */
 @Composable
 fun ProfileScreen() {
     val viewModel = koinViewModel<ProfileViewModel>()
     val state by viewModel.state.collectAsState()
     ProfileScreenContent(
-        state           = state,
-        onEditClick     = viewModel::onEditClick,
-        onCancelClick   = viewModel::onCancelClick,
-        onNameChange    = viewModel::onNameChange,
+        state              = state,
+        onEditClick        = viewModel::onEditClick,
+        onCancelClick      = viewModel::onCancelClick,
+        onNameChange       = viewModel::onNameChange,
         onTargetLowChange  = viewModel::onTargetLowChange,
         onTargetHighChange = viewModel::onTargetHighChange,
-        onSaveClick     = viewModel::onSaveClick
+        onSaveClick        = viewModel::onSaveClick,
+        onAvatarPicked     = viewModel::onAvatarPicked,
+        onRemoveAvatar     = viewModel::onRemoveAvatar
     )
 }
 
@@ -80,6 +100,8 @@ fun ProfileScreenContent(
     onTargetLowChange: (String) -> Unit,
     onTargetHighChange: (String) -> Unit,
     onSaveClick: () -> Unit,
+    onAvatarPicked: (ByteArray) -> Unit,
+    onRemoveAvatar: () -> Unit,
     modifier: Modifier = Modifier
 ) {
     val spacing = MaterialTheme.basilSpacing
@@ -92,7 +114,14 @@ fun ProfileScreenContent(
         verticalArrangement = Arrangement.spacedBy(spacing.xl)
     ) {
         // ── Avatar + name header ──────────────────────────────
-        ProfileHeader(name = state.name, email = state.email)
+        ProfileHeader(
+            name             = state.name,
+            email            = state.email,
+            avatarUrl        = state.avatarUrl,
+            isUploading      = state.isUploadingAvatar,
+            onAvatarPicked   = onAvatarPicked,
+            onRemoveAvatar   = onRemoveAvatar
+        )
 
         // ── Account section ───────────────────────────────────
         ProfileSection(title = stringResource(Res.string.profile_section_account)) {
@@ -209,24 +238,101 @@ fun ProfileScreenContent(
 // ─────────────────────────────────────────────────────────────
 
 @Composable
-private fun ProfileHeader(name: String, email: String) {
+private fun ProfileHeader(
+    name: String,
+    email: String,
+    avatarUrl: String?,
+    isUploading: Boolean,
+    onAvatarPicked: (ByteArray) -> Unit,
+    onRemoveAvatar: () -> Unit
+) {
+    val spacing = MaterialTheme.basilSpacing
+    val coroutineScope = rememberCoroutineScope()
+    val platformContext = LocalPlatformContext.current
+
+    val pickerLauncher = rememberFilePickerLauncher(
+        type = FilePickerFileType.Image,
+        selectionMode = FilePickerSelectionMode.Single
+    ) { files ->
+        val file = files.firstOrNull() ?: return@rememberFilePickerLauncher
+        coroutineScope.launch {
+            val bytes = file.readByteArray(platformContext)
+            onAvatarPicked(bytes)
+        }
+    }
+
     Column(
         modifier            = Modifier.fillMaxWidth(),
         horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.spacedBy(MaterialTheme.basilSpacing.sm)
+        verticalArrangement = Arrangement.spacedBy(spacing.sm)
     ) {
-        // Initials avatar
-        Surface(
-            modifier  = Modifier.size(72.dp).clip(CircleShape),
-            color     = MaterialTheme.colorScheme.primaryContainer
-        ) {
-            Text(
-                text      = name.initials(),
-                modifier  = Modifier.fillMaxSize().padding(top = 18.dp),
-                textAlign = TextAlign.Center,
-                style     = MaterialTheme.typography.headlineMedium,
-                color     = MaterialTheme.colorScheme.onPrimaryContainer
-            )
+        // Avatar with overlay controls
+        Box(contentAlignment = Alignment.BottomEnd) {
+            if (avatarUrl != null) {
+                AsyncImage(
+                    model             = avatarUrl,
+                    contentDescription = stringResource(Res.string.cd_profile_avatar),
+                    contentScale      = ContentScale.Crop,
+                    modifier          = Modifier.size(72.dp).clip(CircleShape)
+                )
+            } else {
+                Surface(
+                    modifier  = Modifier.size(72.dp).clip(CircleShape),
+                    color     = MaterialTheme.colorScheme.primaryContainer
+                ) {
+                    if (isUploading) {
+                        CircularProgressIndicator(
+                            modifier  = Modifier.padding(16.dp),
+                            color     = MaterialTheme.colorScheme.onPrimaryContainer,
+                            strokeWidth = 2.dp
+                        )
+                    } else {
+                        Text(
+                            text      = name.initials(),
+                            modifier  = Modifier.fillMaxSize().padding(top = 18.dp),
+                            textAlign = TextAlign.Center,
+                            style     = MaterialTheme.typography.headlineMedium,
+                            color     = MaterialTheme.colorScheme.onPrimaryContainer
+                        )
+                    }
+                }
+            }
+
+            // Camera button (bottom-end of avatar)
+            if (!isUploading) {
+                IconButton(
+                    onClick = { pickerLauncher.launch() },
+                    modifier = Modifier.size(28.dp),
+                    colors = IconButtonDefaults.iconButtonColors(
+                        containerColor = MaterialTheme.colorScheme.secondaryContainer,
+                        contentColor   = MaterialTheme.colorScheme.onSecondaryContainer
+                    )
+                ) {
+                    Icon(
+                        imageVector        = Icons.Default.AddAPhoto,
+                        contentDescription = stringResource(Res.string.profile_pick_photo),
+                        modifier           = Modifier.size(16.dp)
+                    )
+                }
+            }
+        }
+
+        // Remove photo button — only shown when an avatar exists
+        if (avatarUrl != null && !isUploading) {
+            TextButton(
+                onClick = onRemoveAvatar
+            ) {
+                Icon(
+                    imageVector        = Icons.Default.Close,
+                    contentDescription = null,
+                    modifier           = Modifier.size(16.dp)
+                )
+                Spacer(Modifier.size(spacing.xs))
+                Text(
+                    text  = stringResource(Res.string.profile_remove_photo),
+                    style = MaterialTheme.typography.labelMedium
+                )
+            }
         }
 
         if (name.isNotBlank()) {
@@ -316,7 +422,9 @@ internal fun ProfileScreenContentPreview() {
             onNameChange       = {},
             onTargetLowChange  = {},
             onTargetHighChange = {},
-            onSaveClick        = {}
+            onSaveClick        = {},
+            onAvatarPicked     = {},
+            onRemoveAvatar     = {}
         )
     }
 }
@@ -338,7 +446,9 @@ internal fun ProfileScreenEditingPreview() {
             onNameChange       = {},
             onTargetLowChange  = {},
             onTargetHighChange = {},
-            onSaveClick        = {}
+            onSaveClick        = {},
+            onAvatarPicked     = {},
+            onRemoveAvatar     = {}
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
@@ -96,16 +96,17 @@ class ProfileViewModel(
 
     fun onAvatarPicked(imageBytes: ByteArray) {
         val userId = getUser()?.id ?: return
-        _state.update { it.copy(isUploadingAvatar = true, error = null) }
+        // Show the picked image immediately before the upload completes
+        _state.update { it.copy(pendingAvatarBytes = imageBytes, isUploadingAvatar = true, error = null) }
         coroutineScope.launch {
             avatarRepository.uploadAvatar(userId, imageBytes)
                 .onSuccess { url ->
                     userRepository.updateAvatarUrl(userId, url)
-                    _state.update { it.copy(avatarUrl = url, isUploadingAvatar = false) }
+                    _state.update { it.copy(avatarUrl = url, pendingAvatarBytes = null, isUploadingAvatar = false) }
                 }
                 .onFailure {
                     _state.update {
-                        it.copy(isUploadingAvatar = false, error = Res.string.error_avatar_upload_failed)
+                        it.copy(pendingAvatarBytes = null, isUploadingAvatar = false, error = Res.string.error_avatar_upload_failed)
                     }
                 }
         }
@@ -144,6 +145,7 @@ data class ProfileState(
     val name: String               = "",
     val email: String              = "",
     val avatarUrl: String?         = null,
+    val pendingAvatarBytes: ByteArray? = null,
     val isUploadingAvatar: Boolean = false,
     val targetBgLow: String        = "",
     val targetBgHigh: String       = "",

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModel.kt
@@ -2,13 +2,19 @@ package org.weekendware.basil.presentation.profile
 
 import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_avatar_upload_failed
 import basil.composeapp.generated.resources.error_profile_save_failed
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.data.repository.AvatarRepository
+import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.GetBgTargetsUseCase
 import org.weekendware.basil.domain.usecase.GetUserUseCase
 import org.weekendware.basil.domain.usecase.SetBgTargetsUseCase
@@ -17,13 +23,19 @@ import org.weekendware.basil.domain.usecase.SetBgTargetsUseCase
  * ViewModel for [ProfileScreen].
  *
  * Loads the current user and their BG targets on init, and exposes
- * an edit/save flow for updating targets and display name.
+ * an edit/save flow for updating targets and display name. Handles
+ * avatar upload and removal via [AvatarRepository].
  */
 class ProfileViewModel(
     private val getUser: GetUserUseCase,
     private val getBgTargets: GetBgTargetsUseCase,
-    private val setBgTargets: SetBgTargetsUseCase
+    private val setBgTargets: SetBgTargetsUseCase,
+    private val avatarRepository: AvatarRepository,
+    private val userRepository: UserRepository,
+    private val scope: CoroutineScope? = null
 ) : ViewModel() {
+
+    private val coroutineScope get() = scope ?: viewModelScope
 
     private val _state = MutableStateFlow(ProfileState())
     val state: StateFlow<ProfileState> = _state.asStateFlow()
@@ -39,6 +51,7 @@ class ProfileViewModel(
             it.copy(
                 name         = user?.name ?: "",
                 email        = user?.email ?: "",
+                avatarUrl    = user?.avatarUrl,
                 targetBgLow  = formatTarget(targets.low),
                 targetBgHigh = formatTarget(targets.high)
             )
@@ -81,6 +94,40 @@ class ProfileViewModel(
             .onFailure { _state.update { it.copy(error = Res.string.error_profile_save_failed) } }
     }
 
+    fun onAvatarPicked(imageBytes: ByteArray) {
+        val userId = getUser()?.id ?: return
+        _state.update { it.copy(isUploadingAvatar = true, error = null) }
+        coroutineScope.launch {
+            avatarRepository.uploadAvatar(userId, imageBytes)
+                .onSuccess { url ->
+                    userRepository.updateAvatarUrl(userId, url)
+                    _state.update { it.copy(avatarUrl = url, isUploadingAvatar = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(isUploadingAvatar = false, error = Res.string.error_avatar_upload_failed)
+                    }
+                }
+        }
+    }
+
+    fun onRemoveAvatar() {
+        val userId = getUser()?.id ?: return
+        _state.update { it.copy(isUploadingAvatar = true, error = null) }
+        coroutineScope.launch {
+            avatarRepository.deleteAvatar(userId)
+                .onSuccess {
+                    userRepository.updateAvatarUrl(userId, null)
+                    _state.update { it.copy(avatarUrl = null, isUploadingAvatar = false) }
+                }
+                .onFailure {
+                    _state.update {
+                        it.copy(isUploadingAvatar = false, error = Res.string.error_avatar_upload_failed)
+                    }
+                }
+        }
+    }
+
     fun clearError() {
         _state.update { it.copy(error = null) }
     }
@@ -94,10 +141,12 @@ class ProfileViewModel(
 
 @Immutable
 data class ProfileState(
-    val name: String          = "",
-    val email: String         = "",
-    val targetBgLow: String   = "",
-    val targetBgHigh: String  = "",
-    val isEditing: Boolean    = false,
-    val error: StringResource? = null
+    val name: String               = "",
+    val email: String              = "",
+    val avatarUrl: String?         = null,
+    val isUploadingAvatar: Boolean = false,
+    val targetBgLow: String        = "",
+    val targetBgHigh: String       = "",
+    val isEditing: Boolean         = false,
+    val error: StringResource?     = null
 )

--- a/composeApp/src/commonMain/sqldelight/org.weekendware.basil/database/1.sqm
+++ b/composeApp/src/commonMain/sqldelight/org.weekendware.basil/database/1.sqm
@@ -1,0 +1,1 @@
+ALTER TABLE User ADD COLUMN avatar_url TEXT;

--- a/composeApp/src/commonMain/sqldelight/org.weekendware.basil/database/User.sq
+++ b/composeApp/src/commonMain/sqldelight/org.weekendware.basil/database/User.sq
@@ -1,7 +1,8 @@
 CREATE TABLE User(
     id TEXT NOT NULL PRIMARY KEY,
     name TEXT NOT NULL,
-    email TEXT NOT NULL
+    email TEXT NOT NULL,
+    avatar_url TEXT
 );
 
 selectAll:
@@ -10,6 +11,9 @@ SELECT * FROM User;
 insertUser:
 INSERT INTO User(id, name, email)
 VALUES (?, ?, ?);
+
+updateAvatarUrl:
+UPDATE User SET avatar_url = ? WHERE id = ?;
 
 deleteAll:
 DELETE FROM User;

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,8 @@ buildkonfig = "0.15.2"
 supabase = "3.1.4"
 sentry = "0.25.0"
 ktor = "3.1.2"
+coil = "3.1.0"
+calf = "0.7.0"
 
 
 [libraries]
@@ -58,6 +60,10 @@ sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", 
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
+supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
+calf-file-picker = { module = "com.mohamedrejeb.calf:calf-file-picker", version.ref = "calf" }
 sentry-kmp = { module = "io.sentry:sentry-kotlin-multiplatform", version.ref = "sentry" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
 ktor-client-okhttp = { module = "io.ktor:ktor-client-okhttp", version.ref = "ktor" }


### PR DESCRIPTION
## Summary

- Adds real profile picture upload/remove backed by Supabase Storage (`avatars` bucket)
- SQLDelight schema migration adds `avatar_url` column to `User` table
- `calf-file-picker` (v0.7.0) for cross-platform image picking; Coil 3 for async image loading
- `ProfileViewModel` gains `onAvatarPicked(ByteArray)` and `onRemoveAvatar()` with coroutine-based upload/delete
- `ProfileScreen` replaces the initials placeholder with a `AsyncImage`, camera overlay button, and a "Remove photo" link when an avatar exists

## Test plan

- [ ] Sign in and navigate to Profile
- [ ] Tap the camera icon — file picker opens
- [ ] Select an image — avatar uploads and displays in the circle
- [ ] App restart — avatar URL persists (loaded from SQLDelight)
- [ ] Tap "Remove photo" — avatar clears both remotely and locally
- [ ] Upload failure (e.g., revoke Storage bucket access) — error message shown