### PR TITLE
Add preview coverage for all composables

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.navigation.NavGraph.Companion.findStartDestination
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -120,15 +121,24 @@ private fun MainApp() {
     Scaffold(
         topBar = {
             BasilTopAppBar(
-                navController = navController,
-                currentRoute = currentRoute
+                currentRoute    = currentRoute,
+                onSettingsClick = { navController.navigate(AppRoute.Settings.route) },
+                onBackClick     = { navController.popBackStack() }
             )
         },
         bottomBar = {
             if (currentRoute in AppRoute.tabRoutes) {
                 BasilBottomBar(
-                    navController = navController,
-                    currentRoute = currentRoute
+                    currentRoute = currentRoute,
+                    onNavigate   = { route ->
+                        navController.navigate(route) {
+                            popUpTo(navController.graph.findStartDestination().id) {
+                                saveState = true
+                            }
+                            launchSingleTop = true
+                            restoreState    = true
+                        }
+                    }
                 )
             }
         }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
@@ -46,6 +46,7 @@ import basil.composeapp.generated.resources.auth_signup_subtitle
 import basil.composeapp.generated.resources.auth_toggle_to_signin
 import basil.composeapp.generated.resources.auth_toggle_to_signup
 import basil.composeapp.generated.resources.auth_welcome_back
+import basil.composeapp.generated.resources.error_auth_failed
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
@@ -315,6 +316,42 @@ internal fun AuthScreenSignUpPreview() {
     BasilTheme {
         AuthScreenContent(
             state            = AuthFormState(isSignUp = true),
+            onEmailChange    = {},
+            onPasswordChange = {},
+            onToggle         = {},
+            onSubmit         = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun AuthScreenLoadingPreview() {
+    BasilTheme {
+        AuthScreenContent(
+            state            = AuthFormState(
+                email     = "gavin@example.com",
+                password  = "••••••••",
+                isLoading = true
+            ),
+            onEmailChange    = {},
+            onPasswordChange = {},
+            onToggle         = {},
+            onSubmit         = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun AuthScreenErrorPreview() {
+    BasilTheme {
+        AuthScreenContent(
+            state            = AuthFormState(
+                email  = "gavin@example.com",
+                password = "wrongpassword",
+                error  = Res.string.error_auth_failed
+            ),
             onEmailChange    = {},
             onPasswordChange = {},
             onToggle         = {},

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
@@ -47,8 +47,10 @@ import basil.composeapp.generated.resources.chat_empty_subtitle
 import basil.composeapp.generated.resources.chat_empty_title
 import basil.composeapp.generated.resources.chat_input_placeholder
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.domain.model.ChatMessage
+import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.basilSpacing
 
 /**
@@ -66,15 +68,7 @@ import org.weekendware.basil.presentation.theme.basilSpacing
 fun ChatScreen() {
     val viewModel = koinViewModel<ChatViewModel>()
     val state by viewModel.state.collectAsState()
-    val listState = rememberLazyListState()
     val snackbarHostState = remember { SnackbarHostState() }
-
-    // Scroll to the bottom whenever the message list grows.
-    LaunchedEffect(state.messages.size) {
-        if (state.messages.isNotEmpty()) {
-            listState.animateScrollToItem(state.messages.lastIndex)
-        }
-    }
 
     // Show the error snackbar and clear the error when dismissed.
     val error = state.error
@@ -85,7 +79,36 @@ fun ChatScreen() {
         }
     }
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    ChatScreenContent(
+        state            = state,
+        snackbarHostState = snackbarHostState,
+        onInputChange    = viewModel::onInputChange,
+        onSend           = viewModel::sendMessage
+    )
+}
+
+/**
+ * Stateless chat UI — accepts all state and callbacks so it can be
+ * independently previewed and tested.
+ */
+@Composable
+fun ChatScreenContent(
+    state: ChatState,
+    snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
+    onInputChange: (String) -> Unit,
+    onSend: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    val listState = rememberLazyListState()
+
+    // Scroll to the bottom whenever the message list grows.
+    LaunchedEffect(state.messages.size) {
+        if (state.messages.isNotEmpty()) {
+            listState.animateScrollToItem(state.messages.lastIndex)
+        }
+    }
+
+    Box(modifier = modifier.fillMaxSize()) {
         Column(
             modifier = Modifier
                 .fillMaxSize()
@@ -104,7 +127,7 @@ fun ChatScreen() {
                             .padding(horizontal = spacing.md),
                         verticalArrangement = Arrangement.spacedBy(spacing.sm),
                         contentPadding = PaddingValues(
-                            top = spacing.md,
+                            top    = spacing.md,
                             bottom = spacing.md,
                         ),
                     ) {
@@ -124,9 +147,9 @@ fun ChatScreen() {
 
             // ── Input bar ─────────────────────────────────────────
             ChatInputBar(
-                input = state.input,
-                onInputChange = viewModel::onInputChange,
-                onSend = viewModel::sendMessage,
+                input         = state.input,
+                onInputChange = onInputChange,
+                onSend        = onSend,
                 isSendEnabled = state.input.isNotBlank() && !state.isLoading,
             )
         }
@@ -134,7 +157,7 @@ fun ChatScreen() {
         // ── Error snackbar ────────────────────────────────────────
         SnackbarHost(
             hostState = snackbarHostState,
-            modifier = Modifier.align(Alignment.BottomCenter),
+            modifier  = Modifier.align(Alignment.BottomCenter),
         )
     }
 }
@@ -143,7 +166,7 @@ fun ChatScreen() {
  * Shown when the conversation has no messages yet.
  */
 @Composable
-private fun ChatEmptyState(modifier: Modifier = Modifier) {
+internal fun ChatEmptyState(modifier: Modifier = Modifier) {
     val spacing = MaterialTheme.basilSpacing
     Column(
         modifier = modifier.padding(horizontal = spacing.xl),
@@ -151,13 +174,13 @@ private fun ChatEmptyState(modifier: Modifier = Modifier) {
         verticalArrangement = Arrangement.Center,
     ) {
         Text(
-            text = stringResource(Res.string.chat_empty_title),
+            text  = stringResource(Res.string.chat_empty_title),
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onSurface,
         )
         Spacer(modifier = Modifier.height(spacing.sm))
         Text(
-            text = stringResource(Res.string.chat_empty_subtitle),
+            text  = stringResource(Res.string.chat_empty_subtitle),
             style = MaterialTheme.typography.bodyMedium,
             color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
@@ -173,8 +196,8 @@ private fun ChatEmptyState(modifier: Modifier = Modifier) {
  * signal to the user that more content is on the way.
  */
 @Composable
-private fun MessageBubble(message: ChatMessage) {
-    val isUser = message.role == "user"
+internal fun MessageBubble(message: ChatMessage) {
+    val isUser     = message.role == "user"
     val bubbleColor = if (isUser)
         MaterialTheme.colorScheme.primaryContainer
     else
@@ -183,7 +206,7 @@ private fun MessageBubble(message: ChatMessage) {
         MaterialTheme.colorScheme.onPrimaryContainer
     else
         MaterialTheme.colorScheme.onSecondaryContainer
-    val alignment = if (isUser) Alignment.End else Alignment.Start
+    val alignment  = if (isUser) Alignment.End else Alignment.Start
     val bubbleShape = if (isUser) {
         RoundedCornerShape(topStart = 16.dp, topEnd = 4.dp, bottomStart = 16.dp, bottomEnd = 16.dp)
     } else {
@@ -191,20 +214,19 @@ private fun MessageBubble(message: ChatMessage) {
     }
 
     Column(
-        modifier = Modifier.fillMaxWidth(),
+        modifier            = Modifier.fillMaxWidth(),
         horizontalAlignment = alignment,
     ) {
         Surface(
-            modifier = Modifier.widthIn(max = 280.dp),
-            shape = bubbleShape,
-            color = bubbleColor,
+            modifier       = Modifier.widthIn(max = 280.dp),
+            shape          = bubbleShape,
+            color          = bubbleColor,
             tonalElevation = 1.dp,
         ) {
             Text(
-                // Append a block cursor while the reply is still streaming.
-                text = if (message.isStreaming) message.content + "▋" else message.content,
-                style = MaterialTheme.typography.bodyMedium,
-                color = textColor,
+                text     = if (message.isStreaming) message.content + "▋" else message.content,
+                style    = MaterialTheme.typography.bodyMedium,
+                color    = textColor,
                 modifier = Modifier.padding(horizontal = 12.dp, vertical = 8.dp),
             )
         }
@@ -216,7 +238,7 @@ private fun MessageBubble(message: ChatMessage) {
  * assistant has not yet emitted its first token.
  */
 @Composable
-private fun TypingIndicator() {
+internal fun TypingIndicator() {
     Row(
         modifier = Modifier
             .padding(vertical = 4.dp)
@@ -229,7 +251,7 @@ private fun TypingIndicator() {
             .background(MaterialTheme.colorScheme.secondaryContainer)
             .padding(horizontal = 16.dp, vertical = 12.dp),
         horizontalArrangement = Arrangement.spacedBy(4.dp),
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment     = Alignment.CenterVertically,
     ) {
         repeat(3) {
             Box(
@@ -249,15 +271,9 @@ private fun TypingIndicator() {
  *
  * The send button and keyboard action are disabled while the previous message
  * is still loading or the input is blank.
- *
- * @param input         The current text field value.
- * @param onInputChange Called when the user edits the text.
- * @param onSend        Called when the user taps send or presses the keyboard
- *                      action button.
- * @param isSendEnabled Whether the send action is active.
  */
 @Composable
-private fun ChatInputBar(
+internal fun ChatInputBar(
     input: String,
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
@@ -265,30 +281,30 @@ private fun ChatInputBar(
 ) {
     val spacing = MaterialTheme.basilSpacing
     Surface(
-        modifier = Modifier.fillMaxWidth(),
+        modifier       = Modifier.fillMaxWidth(),
         tonalElevation = 3.dp,
     ) {
         Row(
             modifier = Modifier
                 .fillMaxWidth()
                 .padding(horizontal = spacing.md, vertical = spacing.sm),
-            verticalAlignment = Alignment.CenterVertically,
+            verticalAlignment     = Alignment.CenterVertically,
             horizontalArrangement = Arrangement.spacedBy(spacing.sm),
         ) {
             OutlinedTextField(
-                value = input,
+                value         = input,
                 onValueChange = onInputChange,
-                modifier = Modifier.weight(1f),
-                placeholder = {
+                modifier      = Modifier.weight(1f),
+                placeholder   = {
                     Text(
-                        text = stringResource(Res.string.chat_input_placeholder),
+                        text  = stringResource(Res.string.chat_input_placeholder),
                         style = MaterialTheme.typography.bodyMedium,
                     )
                 },
                 keyboardOptions = KeyboardOptions(imeAction = ImeAction.Send),
                 keyboardActions = KeyboardActions(onSend = { if (isSendEnabled) onSend() }),
-                maxLines = 4,
-                shape = RoundedCornerShape(24.dp),
+                maxLines        = 4,
+                shape           = RoundedCornerShape(24.dp),
             )
 
             IconButton(
@@ -296,14 +312,126 @@ private fun ChatInputBar(
                 enabled = isSendEnabled,
             ) {
                 Icon(
-                    imageVector = Icons.AutoMirrored.Filled.Send,
+                    imageVector        = Icons.AutoMirrored.Filled.Send,
                     contentDescription = stringResource(Res.string.cd_send_message),
-                    tint = if (isSendEnabled)
+                    tint               = if (isSendEnabled)
                         MaterialTheme.colorScheme.primary
                     else
                         MaterialTheme.colorScheme.onSurface.copy(alpha = 0.38f),
                 )
             }
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun ChatScreenEmptyPreview() {
+    BasilTheme {
+        ChatScreenContent(
+            state         = ChatState(),
+            onInputChange = {},
+            onSend        = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ChatScreenWithMessagesPreview() {
+    BasilTheme {
+        ChatScreenContent(
+            state = ChatState(
+                messages = listOf(
+                    ChatMessage(id = "1", role = "user",      content = "What should I eat before a run?"),
+                    ChatMessage(id = "2", role = "assistant", content = "For a run, aim for easily digestible carbs about 30–60 minutes before. A banana or a small bowl of oats works well."),
+                    ChatMessage(id = "3", role = "user",      content = "How much insulin should I reduce?"),
+                    ChatMessage(id = "4", role = "assistant", content = "That depends on exercise intensity and duration. Generally a 20–50% reduction for moderate activity, but always check with your diabetes team first."),
+                )
+            ),
+            onInputChange = {},
+            onSend        = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ChatScreenLoadingPreview() {
+    BasilTheme {
+        ChatScreenContent(
+            state = ChatState(
+                messages  = listOf(
+                    ChatMessage(id = "1", role = "user", content = "Will exercise lower my BG?")
+                ),
+                isLoading = true
+            ),
+            onInputChange = {},
+            onSend        = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ChatScreenWithInputPreview() {
+    BasilTheme {
+        ChatScreenContent(
+            state         = ChatState(input = "How do I adjust for a high-fat meal?"),
+            onInputChange = {},
+            onSend        = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun MessageBubbleUserPreview() {
+    BasilTheme {
+        MessageBubble(ChatMessage(id = "1", role = "user", content = "What's a good snack for overnight lows?"))
+    }
+}
+
+@Preview
+@Composable
+internal fun MessageBubbleAssistantPreview() {
+    BasilTheme {
+        MessageBubble(ChatMessage(id = "1", role = "assistant", content = "15g of fast-acting carbs — glucose tablets, juice, or regular soda. Recheck in 15 minutes."))
+    }
+}
+
+@Preview
+@Composable
+internal fun MessageBubbleStreamingPreview() {
+    BasilTheme {
+        MessageBubble(ChatMessage(id = "1", role = "assistant", content = "Glucose tablets work best", isStreaming = true))
+    }
+}
+
+@Preview
+@Composable
+internal fun TypingIndicatorPreview() {
+    BasilTheme {
+        TypingIndicator()
+    }
+}
+
+@Preview
+@Composable
+internal fun ChatInputBarEmptyPreview() {
+    BasilTheme {
+        ChatInputBar(input = "", onInputChange = {}, onSend = {}, isSendEnabled = false)
+    }
+}
+
+@Preview
+@Composable
+internal fun ChatInputBarWithTextPreview() {
+    BasilTheme {
+        ChatInputBar(input = "How do I count carbs in pizza?", onInputChange = {}, onSend = {}, isSendEnabled = true)
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilBottomBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilBottomBar.kt
@@ -10,15 +10,15 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.navigation.NavController
-import androidx.navigation.NavGraph.Companion.findStartDestination
 import basil.composeapp.generated.resources.Res
 import basil.composeapp.generated.resources.nav_chat
 import basil.composeapp.generated.resources.nav_home
 import basil.composeapp.generated.resources.nav_profile
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.weekendware.basil.AppRoute
+import org.weekendware.basil.presentation.theme.BasilTheme
 
 private data class BottomNavItem(
     val route:    String,
@@ -36,32 +36,51 @@ private val tabItems = listOf(
  * The bottom navigation bar for the Basil app.
  *
  * Renders a [NavigationBar] item for each of the three main tabs. Tapping an
- * item navigates to that tab's destination, preserving state and avoiding
- * back-stack duplication via [NavController.navigate] with [launchSingleTop].
+ * item calls [onNavigate] with the destination route; the caller is responsible
+ * for the actual navigation logic (single-top, state restoration, etc.).
  *
- * @param navController The [NavController] used for navigation events.
- * @param currentRoute  The currently-active route, used to highlight the
- *   selected item.
+ * @param currentRoute  The currently-active route, used to highlight the selected item.
+ * @param onNavigate    Called with the target route when a tab is tapped.
  */
 @Composable
-fun BasilBottomBar(navController: NavController, currentRoute: String?) {
+fun BasilBottomBar(currentRoute: String?, onNavigate: (String) -> Unit) {
     NavigationBar {
         tabItems.forEach { item ->
             val label = stringResource(item.labelRes)
             NavigationBarItem(
                 selected = currentRoute == item.route,
-                onClick  = {
-                    navController.navigate(item.route) {
-                        popUpTo(navController.graph.findStartDestination().id) {
-                            saveState = true
-                        }
-                        launchSingleTop = true
-                        restoreState    = true
-                    }
-                },
-                icon  = { Icon(item.icon, contentDescription = label) },
-                label = { Text(label) }
+                onClick  = { onNavigate(item.route) },
+                icon     = { Icon(item.icon, contentDescription = label) },
+                label    = { Text(label) }
             )
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun BasilBottomBarHomePreview() {
+    BasilTheme {
+        BasilBottomBar(currentRoute = AppRoute.Home.route, onNavigate = {})
+    }
+}
+
+@Preview
+@Composable
+internal fun BasilBottomBarProfilePreview() {
+    BasilTheme {
+        BasilBottomBar(currentRoute = AppRoute.Profile.route, onNavigate = {})
+    }
+}
+
+@Preview
+@Composable
+internal fun BasilBottomBarChatPreview() {
+    BasilTheme {
+        BasilBottomBar(currentRoute = AppRoute.Chat.route, onNavigate = {})
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilLeaf.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilLeaf.kt
@@ -1,19 +1,26 @@
 package org.weekendware.basil.presentation.components
 
 import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.semantics.clearAndSetSemantics
-import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.StrokeCap
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.semantics.clearAndSetSemantics
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
 
 /**
  * The Basil leaf logo mark, drawn with [Canvas].
@@ -80,4 +87,34 @@ private fun DrawScope.drawLeaf(fill: Color, vein: Color) {
         cubicTo(x(14f), y(20f), x(19.5f), y(16f), x(21.5f), y(11f))
     }
     drawPath(rightVein, color = vein.copy(alpha = 0.7f), style = thinStyle)
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun BasilLeafDefaultPreview() {
+    BasilTheme {
+        Box(
+            contentAlignment = Alignment.Center,
+            modifier = Modifier.padding(16.dp)
+        ) {
+            BasilLeaf()
+        }
+    }
+}
+
+@Preview
+@Composable
+internal fun BasilLeafLargeOnSagePreview() {
+    Box(
+        contentAlignment = Alignment.Center,
+        modifier = Modifier
+            .background(BasilPalette.Sage600)
+            .padding(24.dp)
+    ) {
+        BasilLeaf(size = 64.dp, fill = Color.White, vein = BasilPalette.Sage800)
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilTopAppBar.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/components/BasilTopAppBar.kt
@@ -9,29 +9,35 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.navigation.NavController
 import basil.composeapp.generated.resources.Res
 import basil.composeapp.generated.resources.cd_close
 import basil.composeapp.generated.resources.cd_settings
 import basil.composeapp.generated.resources.screen_settings
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.weekendware.basil.AppRoute
+import org.weekendware.basil.presentation.theme.BasilTheme
 
 /**
  * The top app bar used across all Basil screens.
  *
  * Behaviour adapts based on the currently-active route:
  * - **Tab screens** (Home, Profile, Chat): shows a settings gear icon in the
- *   trailing actions area. Tapping it navigates to [AppRoute.Settings].
+ *   trailing actions area. Tapping it calls [onSettingsClick].
  * - **Stack screens** (Settings): shows a close icon in the leading navigation
- *   slot. Tapping it pops back to the previous destination.
+ *   slot. Tapping it calls [onBackClick].
  *
- * @param navController The [NavController] used for navigation events.
- * @param currentRoute  The currently-active route string.
+ * @param currentRoute    The currently-active route string.
+ * @param onSettingsClick Called when the settings gear is tapped on tab screens.
+ * @param onBackClick     Called when the close icon is tapped on stack screens.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun BasilTopAppBar(navController: NavController, currentRoute: String?) {
+fun BasilTopAppBar(
+    currentRoute: String?,
+    onSettingsClick: () -> Unit,
+    onBackClick: () -> Unit
+) {
     val isTabScreen = currentRoute == null || currentRoute in AppRoute.tabRoutes
     val title = if (currentRoute == AppRoute.Settings.route) stringResource(Res.string.screen_settings) else ""
 
@@ -39,17 +45,45 @@ fun BasilTopAppBar(navController: NavController, currentRoute: String?) {
         title = { Text(title) },
         navigationIcon = {
             if (!isTabScreen) {
-                IconButton(onClick = { navController.popBackStack() }) {
+                IconButton(onClick = onBackClick) {
                     Icon(Icons.Default.Close, contentDescription = stringResource(Res.string.cd_close))
                 }
             }
         },
         actions = {
             if (isTabScreen) {
-                IconButton(onClick = { navController.navigate(AppRoute.Settings.route) }) {
+                IconButton(onClick = onSettingsClick) {
                     Icon(Icons.Default.Settings, contentDescription = stringResource(Res.string.cd_settings))
                 }
             }
         }
     )
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun BasilTopAppBarTabScreenPreview() {
+    BasilTheme {
+        BasilTopAppBar(
+            currentRoute    = AppRoute.Home.route,
+            onSettingsClick = {},
+            onBackClick     = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun BasilTopAppBarSettingsScreenPreview() {
+    BasilTheme {
+        BasilTopAppBar(
+            currentRoute    = AppRoute.Settings.route,
+            onSettingsClick = {},
+            onBackClick     = {}
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/dashboard/DashboardScreen.kt
@@ -64,9 +64,37 @@ fun DashboardScreen() {
     val loggingViewModel = koinViewModel<LoggingViewModel>()
     val uiState by viewModel.state.collectAsState()
     val showSheet by viewModel.showLogSheet.collectAsState()
+
+    DashboardScreenContent(
+        state         = uiState,
+        onOpenLogSheet = {
+            loggingViewModel.reset()
+            viewModel.openLogSheet()
+        }
+    )
+
+    if (showSheet) {
+        LogEntrySheet(
+            viewModel = loggingViewModel,
+            onDismiss = { viewModel.closeLogSheet() }
+        )
+    }
+}
+
+/**
+ * Stateless dashboard content — the scrollable list and FAB.
+ *
+ * Separated from [DashboardScreen] so it can be independently previewed and tested.
+ */
+@Composable
+fun DashboardScreenContent(
+    state: DashboardState,
+    onOpenLogSheet: () -> Unit,
+    modifier: Modifier = Modifier
+) {
     val spacing = MaterialTheme.basilSpacing
 
-    Box(modifier = Modifier.fillMaxSize()) {
+    Box(modifier = modifier.fillMaxSize()) {
         LazyColumn(
             modifier = Modifier.fillMaxSize(),
             contentPadding = PaddingValues(
@@ -79,7 +107,7 @@ fun DashboardScreen() {
         ) {
             // ── Last reading summary ──────────────────────
             item {
-                LastReadingCard(entry = uiState.lastBgEntry)
+                LastReadingCard(entry = state.lastBgEntry)
             }
 
             // ── Today section header ──────────────────────
@@ -90,10 +118,10 @@ fun DashboardScreen() {
             }
 
             // ── Today's entries or empty state ────────────
-            if (uiState.todayEntries.isEmpty()) {
+            if (state.todayEntries.isEmpty()) {
                 item { EmptyTodayState() }
             } else {
-                items(uiState.todayEntries, key = { it.id }) { entry ->
+                items(state.todayEntries, key = { it.id }) { entry ->
                     LogEntryItem(entry = entry)
                 }
             }
@@ -101,23 +129,13 @@ fun DashboardScreen() {
 
         // ── FAB ───────────────────────────────────────────
         FloatingActionButton(
-            onClick = {
-                loggingViewModel.reset()
-                viewModel.openLogSheet()
-            },
+            onClick  = onOpenLogSheet,
             modifier = Modifier
                 .align(Alignment.BottomEnd)
                 .padding(BasilTokens.FabEdgePadding)
         ) {
             Icon(Icons.Default.Add, contentDescription = stringResource(Res.string.cd_log_entry))
         }
-    }
-
-    if (showSheet) {
-        LogEntrySheet(
-            viewModel = loggingViewModel,
-            onDismiss = { viewModel.closeLogSheet() }
-        )
     }
 }
 
@@ -382,5 +400,54 @@ internal fun LogEntryItemPreview() {
 internal fun EmptyTodayStatePreview() {
     BasilTheme {
         EmptyTodayState()
+    }
+}
+
+@Preview
+@Composable
+internal fun DashboardScreenEmptyPreview() {
+    BasilTheme {
+        DashboardScreenContent(
+            state          = DashboardState(),
+            onOpenLogSheet = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun DashboardScreenWithDataPreview() {
+    BasilTheme {
+        DashboardScreenContent(
+            state = DashboardState(
+                lastBgEntry = LogEntry(
+                    id           = 1L,
+                    timestamp    = 1_746_000_000_000L,
+                    bgValue      = 7.4,
+                    bgUnit       = BgUnit.MMOLL,
+                    insulinUnits = null,
+                    carbsGrams   = null
+                ),
+                todayEntries = listOf(
+                    LogEntry(
+                        id           = 2L,
+                        timestamp    = 1_746_010_000_000L,
+                        bgValue      = 5.5,
+                        bgUnit       = BgUnit.MMOLL,
+                        insulinUnits = 4.0,
+                        carbsGrams   = 60.0
+                    ),
+                    LogEntry(
+                        id           = 3L,
+                        timestamp    = 1_746_000_000_000L,
+                        bgValue      = 7.4,
+                        bgUnit       = BgUnit.MMOLL,
+                        insulinUnits = null,
+                        carbsGrams   = null
+                    )
+                )
+            ),
+            onOpenLogSheet = {}
+        )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LogEntrySheet.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/logging/LogEntrySheet.kt
@@ -252,3 +252,18 @@ internal fun LogEntrySheetContentFilledPreview() {
         )
     }
 }
+
+@Preview
+@Composable
+internal fun LogEntrySheetContentMgdlPreview() {
+    BasilTheme {
+        LogEntrySheetContent(
+            state           = LogFormState(bgValue = "112", bgUnit = BgUnit.MGDL),
+            onBgValueChange = {},
+            onBgUnitChange  = {},
+            onInsulinChange = {},
+            onCarbsChange   = {},
+            onSave          = {}
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -55,6 +55,7 @@ import basil.composeapp.generated.resources.profile_label_target_range
 import basil.composeapp.generated.resources.profile_pick_photo
 import basil.composeapp.generated.resources.profile_placeholder_name
 import basil.composeapp.generated.resources.profile_placeholder_target
+import basil.composeapp.generated.resources.error_profile_save_failed
 import basil.composeapp.generated.resources.profile_remove_photo
 import basil.composeapp.generated.resources.profile_section_account
 import basil.composeapp.generated.resources.profile_section_health
@@ -472,6 +473,31 @@ internal fun ProfileScreenEditingPreview() {
             onSaveClick        = {},
             onAvatarPicked = {},
             onRemoveAvatar = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ProfileScreenErrorPreview() {
+    BasilTheme {
+        ProfileScreenContent(
+            state = ProfileState(
+                name         = "Gavin Dunne",
+                email        = "gavin@weekendware.io",
+                targetBgLow  = "10.0",
+                targetBgHigh = "4.0",
+                isEditing    = true,
+                error        = Res.string.error_profile_save_failed
+            ),
+            onEditClick        = {},
+            onCancelClick      = {},
+            onNameChange       = {},
+            onTargetLowChange  = {},
+            onTargetHighChange = {},
+            onSaveClick        = {},
+            onAvatarPicked     = {},
+            onRemoveAvatar     = {}
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/settings/SettingsScreen.kt
@@ -27,6 +27,7 @@ import basil.composeapp.generated.resources.settings_label_bg_unit
 import basil.composeapp.generated.resources.settings_label_reminders
 import basil.composeapp.generated.resources.settings_label_reminders_hint
 import basil.composeapp.generated.resources.settings_label_version
+import basil.composeapp.generated.resources.error_save_preference_failed
 import basil.composeapp.generated.resources.settings_notifications_coming_soon
 import basil.composeapp.generated.resources.settings_section_about
 import basil.composeapp.generated.resources.settings_section_data
@@ -221,6 +222,20 @@ internal fun SettingsScreenMmollPreview() {
     BasilTheme {
         SettingsScreenContent(
             state          = SettingsState(bgUnit = BgUnit.MMOLL),
+            onBgUnitChange = {}
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun SettingsScreenErrorPreview() {
+    BasilTheme {
+        SettingsScreenContent(
+            state          = SettingsState(
+                bgUnit = BgUnit.MGDL,
+                error  = Res.string.error_save_preference_failed
+            ),
             onBgUnitChange = {}
         )
     }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/splash/SplashScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/splash/SplashScreen.kt
@@ -27,8 +27,10 @@ import basil.composeapp.generated.resources.app_name
 import basil.composeapp.generated.resources.app_type1_label
 import kotlinx.coroutines.delay
 import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.weekendware.basil.presentation.components.BasilLeaf
 import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.BasilTokens
 
 /**
@@ -102,5 +104,19 @@ fun SplashScreen(onFadeComplete: () -> Unit) {
                 letterSpacing = 2.5.sp
             )
         }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun SplashScreenPreview() {
+    BasilTheme {
+        // LaunchedEffect does not fire in preview, so the screen renders at
+        // full opacity showing the static splash layout.
+        SplashScreen(onFadeComplete = {})
     }
 }


### PR DESCRIPTION
## Summary

- **`BasilBottomBar`** — decoupled from `NavController` (accepts `currentRoute` + `onNavigate` callback); 3 previews (Home/Profile/Chat selected)
- **`BasilTopAppBar`** — decoupled from `NavController` (accepts `onSettingsClick` + `onBackClick`); 2 previews (tab screen, settings screen)
- **`BasilLeaf`** — 2 previews (default, large on sage background)
- **`SplashScreen`** — 1 preview (static layout; animation doesn't fire in preview)
- **`ChatScreen`** — extracted `ChatScreenContent` stateless wrapper; sub-composables promoted to `internal`; 10 previews covering empty state, conversation, loading, streaming bubble, input bar
- **`DashboardScreen`** — extracted `DashboardScreenContent`; 2 full-screen previews (empty and with data)
- **`AuthScreen`** — added loading and error state previews
- **`ProfileScreen`** — added error state preview
- **`SettingsScreen`** — added error state preview
- **`LogEntrySheet`** — added mg/dL unit selection preview

## Test plan

- [ ] Open each file in Android Studio / Fleet and verify all previews render without errors
- [ ] Launch Android target and verify navigation still works correctly (NavController refactor)