### PR TITLE
Fix avatar circle crop after photo pick

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/profile/ProfileScreen.kt
@@ -60,6 +60,8 @@ import basil.composeapp.generated.resources.profile_remove_photo
 import basil.composeapp.generated.resources.profile_section_account
 import basil.composeapp.generated.resources.profile_section_health
 import coil3.compose.AsyncImage
+import coil3.compose.LocalPlatformContext as CoilPlatformContext
+import coil3.request.ImageRequest
 import com.mohamedrejeb.calf.core.LocalPlatformContext
 import com.mohamedrejeb.calf.io.readByteArray
 import com.mohamedrejeb.calf.picker.FilePickerFileType
@@ -254,6 +256,7 @@ private fun ProfileHeader(
     val spacing = MaterialTheme.basilSpacing
     val coroutineScope = rememberCoroutineScope()
     val platformContext = LocalPlatformContext.current
+    val coilContext = CoilPlatformContext.current
 
     val pickerLauncher = rememberFilePickerLauncher(
         type = FilePickerFileType.Image,
@@ -282,16 +285,18 @@ private fun ProfileHeader(
             // Image layer: pending bytes take priority over the remote URL
             when {
                 pendingAvatarBytes != null -> AsyncImage(
-                    model              = pendingAvatarBytes,
+                    model = ImageRequest.Builder(coilContext)
+                        .data(pendingAvatarBytes)
+                        .build(),
                     contentDescription = stringResource(Res.string.cd_profile_avatar),
                     contentScale       = ContentScale.Crop,
-                    modifier           = Modifier.fillMaxSize()
+                    modifier           = Modifier.fillMaxSize().clip(CircleShape)
                 )
                 avatarUrl != null -> AsyncImage(
                     model              = avatarUrl,
                     contentDescription = stringResource(Res.string.cd_profile_avatar),
                     contentScale       = ContentScale.Crop,
-                    modifier           = Modifier.fillMaxSize()
+                    modifier           = Modifier.fillMaxSize().clip(CircleShape)
                 )
                 else -> Surface(
                     modifier = Modifier.fillMaxSize(),


### PR DESCRIPTION
## Summary

- Passing a raw `ByteArray` to `AsyncImage` didn't give Coil enough context to decode the image on Android, so the picked photo wasn't rendering
- Now wraps pending bytes in an explicit `ImageRequest.Builder(coilContext).data(bytes).build()` so Coil processes them correctly
- Added `.clip(CircleShape)` directly on both `AsyncImage` calls (belt-and-suspenders alongside the parent Box clip)

## Test plan

- [ ] Pick a photo from the profile screen — circle updates immediately to a circular crop of the selected image
- [ ] Upload completes — URL loads via Coil and still shows as a circular crop
- [ ] Remove photo — circle reverts to initials