### PR TITLE
Architect audit cleanup: remove dead nav-compose dep, fix double-splash

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,7 +62,6 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
-            implementation(libs.androidx.navigation.compose)
             implementation(libs.supabase.auth)
             implementation(libs.supabase.storage)
             implementation(libs.supabase.postgrest)

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -7,19 +7,17 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import org.koin.mp.KoinPlatform
-import org.weekendware.basil.data.repository.AuthRepository
 
 /**
  * The single Android [ComponentActivity] that hosts the entire Basil UI.
  *
  * Responsibilities:
- * - Installs the OS-level SplashScreen and keeps it visible until the Supabase
- *   SDK has resolved the stored session. This covers the cold-start window
- *   before the first Compose frame is drawn.
+ * - Installs the OS-level SplashScreen as a functional pass-through — it exits
+ *   on the first drawn frame and makes no branded statement of its own. The
+ *   Compose [org.weekendware.basil.presentation.splash.SplashScreen] is the
+ *   single source of truth for the branded splash moment, including the wait
+ *   for session restoration. Holding the OS splash on session resolution here
+ *   as well would draw two splashes back-to-back.
  * - Enables edge-to-edge display so content draws behind system bars.
  * - Sets the Compose content root to [App].
  *
@@ -30,21 +28,9 @@ import org.weekendware.basil.data.repository.AuthRepository
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val splashScreen = installSplashScreen()
+        installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        // Keep the OS splash visible until sessionFlow emits its first value.
-        // The first emission means Supabase has finished restoring (or not) the
-        // stored session — at that point the Compose layer is ready to show the
-        // correct screen and the OS splash can exit.
-        var sessionResolved = false
-        val authRepository = KoinPlatform.getKoin().get<AuthRepository>()
-        lifecycleScope.launch {
-            authRepository.sessionFlow.first()
-            sessionResolved = true
-        }
-        splashScreen.setKeepOnScreenCondition { !sessionResolved }
 
         setContent {
             App()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ materialIconsExtended = "1.7.3"
 sqldelight = "2.0.1"
 detekt = "1.23.7"
 mockitoKotlin = "5.4.0"
-navigation = "2.8.0-alpha13"
 buildkonfig = "0.15.2"
 supabase = "3.1.4"
 sentry = "0.25.0"
@@ -63,7 +62,6 @@ sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", vers
 sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
-androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }


### PR DESCRIPTION
## Summary
Pre-build fixes from the splash-auth TDD audit (`tdd-splash-auth-07222026.md`), applied by Architect before any feature work starts on that branch:
- Removed unused `androidx.navigation.compose` dependency (dead — navigation is `AnimatedContent`-based, not `NavHost`)
- Removed `MainActivity`'s `setKeepOnScreenCondition` hold on session resolution — the Compose `SplashScreen` already gates on `SessionState.Loading`, so holding both caused a double-splash on Android (audit CRITICAL/HIGH findings)

## Test plan
- [x] `:composeApp:compileDevDebugKotlinAndroid` — clean compile
- [x] `SplashGateTest` (5 cases) — verified green via `:composeApp:testDevDebugUnitTest`
- [ ] Manual: confirm single splash on a physical/emulated Android device

**Note:** `:composeApp:desktopTest` is currently broken on `develop` independent of this change — `FakeUserRepository` doesn't implement `getAllAsFlow()`, so `ProfileViewModelTest` fails to compile. Flagging separately, not fixed here (out of scope for this audit pass).