### PR TITLE
QA: password strength contract + test suite (splash-auth AC18)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
@@ -1,0 +1,59 @@
+package org.weekendware.basil.presentation.auth
+
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * Strength classification for a candidate password, driving the 3-segment
+ * strength bar on sign-up and the reset flow's new-password step.
+ *
+ * See `spec-splash-auth-07222026.md` AC18 and
+ * `tdd-splash-auth-07222026.md` "Data structures and algorithms".
+ */
+sealed class PasswordStrength {
+    /** No input yet — strength bar is hidden. */
+    data object None : PasswordStrength()
+
+    /** 0–2 of 5 requirements met — 1 red segment. */
+    data object Weak : PasswordStrength()
+
+    /** 3–4 of 5 requirements met — 2 amber segments. */
+    data object Medium : PasswordStrength()
+
+    /** All 5 requirements met — 3 green segments. */
+    data object Strong : PasswordStrength()
+}
+
+/**
+ * One row in the live requirements checklist shown below the strength bar.
+ *
+ * @property label Copy string identifying the requirement — pending Copywriter
+ *   pass (`Res.string.auth_req_*`); not referenced by the validator stub below.
+ * @property met   True once the candidate password satisfies this requirement.
+ */
+data class PasswordRequirement(val label: StringResource, val met: Boolean)
+
+/**
+ * Validates a candidate password against the five table-stakes requirements
+ * and classifies overall strength.
+ *
+ * **Pure function — no side effects, no ViewModel state, no I/O.**
+ * `AuthViewModel.onPasswordChanged` calls this synchronously and writes both
+ * outputs to `AuthUiState`.
+ *
+ * Requirements, in order: minimum 8 characters, uppercase letter, lowercase
+ * letter, number, special character (any non-alphanumeric character).
+ * Strength mapping: `met.size` 0–2 → [PasswordStrength.Weak], 3–4 →
+ * [PasswordStrength.Medium], 5 → [PasswordStrength.Strong]. An empty password
+ * returns [PasswordStrength.None] paired with an empty requirements list.
+ *
+ * **Not implemented here.** This signature is QA scaffolding so
+ * `PasswordStrengthValidatorTest` compiles and runs (red) ahead of
+ * implementation. Backend Builder implements the body per the algorithm
+ * above and the TDD; every test in this suite is expected to fail with
+ * `NotImplementedError` until then.
+ */
+object PasswordStrengthValidator {
+    fun validate(password: String): Pair<PasswordStrength, List<PasswordRequirement>> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC18")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
@@ -5,9 +5,6 @@ import org.jetbrains.compose.resources.StringResource
 /**
  * Strength classification for a candidate password, driving the 3-segment
  * strength bar on sign-up and the reset flow's new-password step.
- *
- * See `spec-splash-auth-07222026.md` AC18 and
- * `tdd-splash-auth-07222026.md` "Data structures and algorithms".
  */
 sealed class PasswordStrength {
     /** No input yet — strength bar is hidden. */
@@ -49,7 +46,7 @@ data class PasswordRequirement(val label: StringResource, val met: Boolean)
  * **Not implemented here.** This signature is QA scaffolding so
  * `PasswordStrengthValidatorTest` compiles and runs (red) ahead of
  * implementation. Backend Builder implements the body per the algorithm
- * above and the TDD; every test in this suite is expected to fail with
+ * documented above; every test in that suite is expected to fail with
  * `NotImplementedError` until then.
  */
 object PasswordStrengthValidator {

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -115,11 +115,19 @@ class PasswordStrengthValidatorTest {
     }
 
     @Test
-    fun `requirements are returned in a stable order — length, uppercase, lowercase, number, special`() {
-        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
-        assertEquals(5, requirements.size)
-        // Order asserted positionally per the TDD's documented sequence;
-        // see the boundary tests above for what each index represents.
+    fun `requirements list has exactly one entry per requirement, in a fixed order`() {
+        // An all-digit, 8-character password meets only length and number —
+        // no letters means no uppercase/lowercase, and digits don't count as
+        // special characters. met=true should land at exactly those two
+        // positions — length (0) and number (3) — pinning down the actual
+        // order (length, uppercase, lowercase, number, special), not just
+        // the list's size; the individual boundary tests above each isolate
+        // one index but never assert the full five-position layout at once.
+        val (_, requirements) = PasswordStrengthValidator.validate("12345678")
+        assertEquals(
+            listOf(true, false, false, true, false),
+            requirements.map { it.met },
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -5,13 +5,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * QA test suite for [PasswordStrengthValidator], written from
- * `tdd-splash-auth-07222026.md` (AC18) ahead of implementation.
+ * QA test suite for [PasswordStrengthValidator], written ahead of
+ * implementation per the team's test-first process. Covers threshold
+ * classification (Weak/Medium/Strong), the length and special-character
+ * boundaries, and requirement-list shape and determinism.
  *
  * All cases are expected to fail with `NotImplementedError` until Backend
- * Builder implements [PasswordStrengthValidator.validate]. See
- * `tests-splash-auth-07232026.md` for the full QA plan — this file covers
- * SPA-052 through SPA-060 and SPA-062.
+ * Builder implements [PasswordStrengthValidator.validate].
  *
  * Deliberately does not assert on [PasswordRequirement.label] — copy is
  * pending a Copywriter pass and is out of scope for this validator's

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -1,0 +1,132 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [PasswordStrengthValidator], written from
+ * `tdd-splash-auth-07222026.md` (AC18) ahead of implementation.
+ *
+ * All cases are expected to fail with `NotImplementedError` until Backend
+ * Builder implements [PasswordStrengthValidator.validate]. See
+ * `tests-splash-auth-07232026.md` for the full QA plan — this file covers
+ * SPA-052 through SPA-060 and SPA-062.
+ *
+ * Deliberately does not assert on [PasswordRequirement.label] — copy is
+ * pending a Copywriter pass and is out of scope for this validator's
+ * contract. Tests assert only on strength classification, `met` values,
+ * and list shape/order.
+ */
+class PasswordStrengthValidatorTest {
+
+    @Test
+    fun `empty password returns None with an empty requirements list`() {
+        val (strength, requirements) = PasswordStrengthValidator.validate("")
+        assertEquals(PasswordStrength.None, strength)
+        assertTrue(requirements.isEmpty())
+    }
+
+    @Test
+    fun `password meeting zero requirements is Weak`() {
+        // Below length, no uppercase, no digit, no special char.
+        val (strength, requirements) = PasswordStrengthValidator.validate("abc")
+        assertEquals(PasswordStrength.Weak, strength)
+        assertEquals(5, requirements.size)
+        assertTrue(requirements.none { it.met })
+    }
+
+    @Test
+    fun `password meeting exactly two requirements is Weak`() {
+        // lowercase + length, nothing else.
+        val (strength, _) = PasswordStrengthValidator.validate("abcdefgh")
+        assertEquals(PasswordStrength.Weak, strength)
+    }
+
+    @Test
+    fun `password meeting exactly three requirements is Medium`() {
+        // length + lowercase + uppercase.
+        val (strength, _) = PasswordStrengthValidator.validate("Abcdefgh")
+        assertEquals(PasswordStrength.Medium, strength)
+    }
+
+    @Test
+    fun `password meeting exactly four requirements is Medium`() {
+        // length + lowercase + uppercase + digit, no special char.
+        val (strength, _) = PasswordStrengthValidator.validate("Abcdefg1")
+        assertEquals(PasswordStrength.Medium, strength)
+    }
+
+    @Test
+    fun `password meeting all five requirements is Strong`() {
+        val (strength, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(PasswordStrength.Strong, strength)
+        assertTrue(requirements.all { it.met })
+    }
+
+    @Test
+    fun `length requirement fails at seven characters and passes at eight`() {
+        val (_, sevenChars) = PasswordStrengthValidator.validate("Abcdef1!".dropLast(1))
+        assertEquals(false, sevenChars[0].met)
+
+        val (_, eightChars) = PasswordStrengthValidator.validate("Abcdef1!")
+        assertEquals(true, eightChars[0].met)
+    }
+
+    @Test
+    fun `uppercase requirement is met only when an uppercase letter is present`() {
+        val (_, withoutUpper) = PasswordStrengthValidator.validate("abcdefg1!")
+        assertEquals(false, withoutUpper[1].met)
+
+        val (_, withUpper) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(true, withUpper[1].met)
+    }
+
+    @Test
+    fun `lowercase requirement is met only when a lowercase letter is present`() {
+        val (_, withoutLower) = PasswordStrengthValidator.validate("ABCDEFG1!")
+        assertEquals(false, withoutLower[2].met)
+
+        val (_, withLower) = PasswordStrengthValidator.validate("ABCDEFGa1!")
+        assertEquals(true, withLower[2].met)
+    }
+
+    @Test
+    fun `number requirement is met only when a digit is present`() {
+        val (_, withoutDigit) = PasswordStrengthValidator.validate("Abcdefgh!")
+        assertEquals(false, withoutDigit[3].met)
+
+        val (_, withDigit) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(true, withDigit[3].met)
+    }
+
+    @Test
+    fun `special character requirement accepts any non-alphanumeric character`() {
+        for (symbol in listOf('!', '-', '#', '@', '_', '.')) {
+            val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1$symbol")
+            assertTrue(requirements[4].met, "Expected '$symbol' to satisfy the special-character requirement")
+        }
+    }
+
+    @Test
+    fun `special character requirement is not met without one`() {
+        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg12")
+        assertEquals(false, requirements[4].met)
+    }
+
+    @Test
+    fun `requirements are returned in a stable order — length, uppercase, lowercase, number, special`() {
+        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(5, requirements.size)
+        // Order asserted positionally per the TDD's documented sequence;
+        // see the boundary tests above for what each index represents.
+    }
+
+    @Test
+    fun `validate is deterministic for the same input`() {
+        val first = PasswordStrengthValidator.validate("Abcdefg1!")
+        val second = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(first.first, second.first)
+        assertEquals(first.second.map { it.met }, second.second.map { it.met })
+    }
+}


### PR DESCRIPTION
## Summary
QA test-first deliverable for splash-auth AC18 (password strength indicator), per `tdd-splash-auth-07222026.md`. Adds the interface QA needs to test against — `PasswordStrength`, `PasswordRequirement`, `PasswordStrengthValidator` — as a signature-only stub (`validate()` throws `TODO()`), plus the full test suite.

**All 14 tests are currently red** (`NotImplementedError`) by design. Backend Builder implements `PasswordStrengthValidator.validate()` per the algorithm documented in the TDD to turn them green. Per team process, QA owns all test files — builders implement production code only and never edit tests.

Tests deliberately don't assert on `PasswordRequirement.label` — that's `Res.string.auth_req_*` copy pending a Copywriter pass, out of scope for this validator's behavioral contract.

Covers SPA-052–SPA-060, SPA-062 in `tests-splash-auth-07232026.md` (WeekendWare repo).

## Test plan
- [x] Compiles clean via `:composeApp:testDevDebugUnitTest`
- [x] 14/14 tests fail with `NotImplementedError` (expected red state)
- [ ] Backend Builder implements `validate()`, all 14 turn green