### PR TITLE
QA: deep link allow-list contract + test suite (splash-auth security)

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
@@ -11,10 +11,6 @@ package org.weekendware.basil.data.repository
  * prevents an open-redirect-style attack where a lookalike deep link tricks
  * the app into exchanging an attacker-controlled code.
  *
- * See `tdd-splash-auth-07222026.md`, "Component design" → `DeepLinkHandler`,
- * and security requirement SPA-098–SPA-100 in
- * `tests-splash-auth-07232026.md`.
- *
  * **Not implemented here.** QA scaffolding only — see
  * [DeepLinkValidatorTest] for the full contract, including the boundary
  * case that rules out a naive `startsWith` implementation.

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
@@ -1,0 +1,39 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Validates an incoming deep link URL against the exact allow-list before
+ * any platform `DeepLinkHandler` passes it to
+ * `client.auth.exchangeCodeForSession(url)`.
+ *
+ * Only two link shapes are ever valid: a password-reset link or an OAuth
+ * callback. Anything else — including a crafted URL where the attacker
+ * controls the trailing path or host segment — must be rejected. This
+ * prevents an open-redirect-style attack where a lookalike deep link tricks
+ * the app into exchanging an attacker-controlled code.
+ *
+ * See `tdd-splash-auth-07222026.md`, "Component design" → `DeepLinkHandler`,
+ * and security requirement SPA-098–SPA-100 in
+ * `tests-splash-auth-07232026.md`.
+ *
+ * **Not implemented here.** QA scaffolding only — see
+ * [DeepLinkValidatorTest] for the full contract, including the boundary
+ * case that rules out a naive `startsWith` implementation.
+ */
+object DeepLinkValidator {
+
+    /** The only two deep link shapes Basil ever handles. */
+    private const val RESET_PASSWORD = "basil://reset-password"
+    private const val AUTH_CALLBACK = "basil://auth/callback"
+
+    /**
+     * True only if [url] is exactly one of the allowed link shapes, or that
+     * shape followed by a query string (`?...`). A URL that merely starts
+     * with the allowed string as raw characters — e.g.
+     * `basil://reset-password-evil.com` — must return false. Backend
+     * Builder implements this with a boundary-aware check, not a plain
+     * `String.startsWith`.
+     */
+    fun isAllowed(url: String): Boolean {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, DeepLinkHandler")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
@@ -1,0 +1,78 @@
+package org.weekendware.basil.data.repository
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [DeepLinkValidator], written from
+ * `tdd-splash-auth-07222026.md` ahead of implementation.
+ *
+ * All cases are expected to fail until Backend Builder implements
+ * [DeepLinkValidator.isAllowed]. Covers SPA-098–SPA-100 in
+ * `tests-splash-auth-07232026.md`.
+ */
+class DeepLinkValidatorTest {
+
+    @Test
+    fun `bare reset-password link is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://reset-password"))
+    }
+
+    @Test
+    fun `reset-password link with a query string is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://reset-password?token=abc123"))
+    }
+
+    @Test
+    fun `bare auth callback link is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://auth/callback"))
+    }
+
+    @Test
+    fun `auth callback link with a query string is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://auth/callback?code=xyz"))
+    }
+
+    @Test
+    fun `a lookalike link that merely starts with the allowed string is rejected`() {
+        // "basil://reset-password-evil.com" is a raw string prefix of
+        // "basil://reset-password" as characters — a naive startsWith()
+        // check would wrongly accept this. The allowed shape ends at the
+        // path boundary (end of string or '?'), not at an arbitrary
+        // continuation of the same characters.
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password-evil.com"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password.attacker.com"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://auth/callbackXYZ"))
+    }
+
+    @Test
+    fun `wrong scheme is rejected even with an otherwise valid path`() {
+        assertFalse(DeepLinkValidator.isAllowed("https://reset-password"))
+        assertFalse(DeepLinkValidator.isAllowed("http://basil.app/reset-password"))
+    }
+
+    @Test
+    fun `unrelated basil scheme paths are rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed("basil://home"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://chat"))
+    }
+
+    @Test
+    fun `empty and blank input is rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed(""))
+        assertFalse(DeepLinkValidator.isAllowed("   "))
+    }
+
+    @Test
+    fun `path traversal style suffix is rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password/../../auth/callback"))
+    }
+
+    @Test
+    fun `case sensitivity — scheme is not matched case-insensitively`() {
+        // Custom URL schemes should be handled literally; do not silently
+        // widen the allow-list via case-insensitive matching.
+        assertFalse(DeepLinkValidator.isAllowed("BASIL://reset-password"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
@@ -5,12 +5,13 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * QA test suite for [DeepLinkValidator], written from
- * `tdd-splash-auth-07222026.md` ahead of implementation.
+ * QA test suite for [DeepLinkValidator], written ahead of implementation
+ * per the team's test-first process. Covers the allowed reset-password
+ * and auth-callback shapes, and the lookalike-prefix boundary case that
+ * rules out a naive `startsWith` implementation.
  *
  * All cases are expected to fail until Backend Builder implements
- * [DeepLinkValidator.isAllowed]. Covers SPA-098–SPA-100 in
- * `tests-splash-auth-07232026.md`.
+ * [DeepLinkValidator.isAllowed].
  */
 class DeepLinkValidatorTest {
 


### PR DESCRIPTION
## Summary
QA test-first deliverable for the splash-auth deep-link security requirement in `tdd-splash-auth-07222026.md`. Adds `DeepLinkValidator.isAllowed()` as a signature-only stub (`TODO()`), plus the full test suite.

**Security note for Backend Builder:** the TDD describes this as "a simple `url.startsWith(...)` check — no regex, no parsing." Taken literally, that's exploitable — `"basil://reset-password-evil.com"` is a valid raw-string prefix of `"basil://reset-password"`, so a plain `startsWith` would let it through. One of the 10 tests (`a lookalike link that merely starts with the allowed string is rejected`) requires a boundary-aware check instead (matching to end-of-string or `?`, not an arbitrary continuation). Flagging this now so it doesn't ship as written.

**All 10 tests are currently red** (`NotImplementedError`) by design. Covers SPA-098–SPA-100 in `tests-splash-auth-07232026.md` (WeekendWare repo).

## Test plan
- [x] Compiles clean via `:composeApp:testDevDebugUnitTest`
- [x] 10/10 tests fail as expected (red state)
- [ ] Backend Builder implements `isAllowed()`, all 10 turn green