### PR TITLE
QA: expand AuthRepository contract for splash-auth, own the fake

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
@@ -35,9 +35,9 @@ interface AuthRepository {
     /** True if a valid session exists. */
     fun isSignedIn(): Boolean
 
-    // ── Splash, Auth & Brand Foundation — added ahead of implementation ──
-    // See tdd-splash-auth-07222026.md, "Interface design". Signatures only;
-    // SupabaseAuthRepository stubs these with TODO() for Backend Builder.
+    // ── Social sign-in, password reset, email verification, passkeys,
+    //    deep links, and detect-by-email — added ahead of implementation.
+    //    SupabaseAuthRepository stubs these with TODO() for Backend Builder.
 
     /** Signs in via Google. Platform-specific implementation. */
     suspend fun signInWithGoogle(): Result<Unit>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
@@ -34,4 +34,41 @@ interface AuthRepository {
 
     /** True if a valid session exists. */
     fun isSignedIn(): Boolean
+
+    // ── Splash, Auth & Brand Foundation — added ahead of implementation ──
+    // See tdd-splash-auth-07222026.md, "Interface design". Signatures only;
+    // SupabaseAuthRepository stubs these with TODO() for Backend Builder.
+
+    /** Signs in via Google. Platform-specific implementation. */
+    suspend fun signInWithGoogle(): Result<Unit>
+
+    /** Signs in via Apple. iOS only natively; OAuth redirect on other platforms. */
+    suspend fun signInWithApple(): Result<Unit>
+
+    /** Sends a password reset email with a deep link back to the app. */
+    suspend fun resetPassword(email: String): Result<Unit>
+
+    /** Resends the verification email to the current user. */
+    suspend fun resendVerificationEmail(): Result<Unit>
+
+    /** True if the current user's email is confirmed. */
+    fun isEmailVerified(): Boolean
+
+    /** Elapsed days since the current user account was created. */
+    fun daysSinceSignup(): Long
+
+    /** Returns the FIDO2 registration challenge from Supabase and initiates platform credential creation. */
+    suspend fun registerPasskey(): Result<Unit>
+
+    /** Returns the FIDO2 authentication challenge from Supabase and initiates platform credential assertion. */
+    suspend fun signInWithPasskey(): Result<Unit>
+
+    /** True if the user has completed FIDO2 registration on this device. */
+    fun hasPasskeyEnrolled(): Boolean
+
+    /** Handles an incoming deep link URL (password reset, OAuth callback). */
+    suspend fun handleDeepLink(url: String): Result<Unit>
+
+    /** Returns the last-used email for detect-by-email default mode. */
+    fun lastUsedEmail(): String?
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -54,4 +54,44 @@ class SupabaseAuthRepository(
 
     override fun isSignedIn(): Boolean =
         client.auth.currentUserOrNull() != null
+
+    // ── Splash, Auth & Brand Foundation — pending implementation ──
+    // Stubs so the module compiles ahead of the feature build. Backend
+    // Builder implements each per tdd-splash-auth-07222026.md; QA's test
+    // suite in commonTest exercises these through FakeAuthRepository until
+    // then. Do not remove the TODO markers without also removing this
+    // comment block.
+
+    override suspend fun signInWithGoogle(): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Google Sign In on KMP")
+
+    override suspend fun signInWithApple(): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Apple Sign In on KMP")
+
+    override suspend fun resetPassword(email: String): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Supabase deep links (password reset)")
+
+    override suspend fun resendVerificationEmail(): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC12")
+
+    override fun isEmailVerified(): Boolean =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Email verification state")
+
+    override fun daysSinceSignup(): Long =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Email verification 30-day window")
+
+    override suspend fun registerPasskey(): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP")
+
+    override suspend fun signInWithPasskey(): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP")
+
+    override fun hasPasskeyEnrolled(): Boolean =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, passkey_enrolled DataStore key")
+
+    override suspend fun handleDeepLink(url: String): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, DeepLinkHandler")
+
+    override fun lastUsedEmail(): String? =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, stored_auth_email DataStore key")
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -55,12 +55,11 @@ class SupabaseAuthRepository(
     override fun isSignedIn(): Boolean =
         client.auth.currentUserOrNull() != null
 
-    // ── Splash, Auth & Brand Foundation — pending implementation ──
-    // Stubs so the module compiles ahead of the feature build. Backend
-    // Builder implements each per tdd-splash-auth-07222026.md; QA's test
+    // ── Social sign-in, password reset, email verification, passkeys,
+    //    deep links, and detect-by-email — pending implementation. ──
+    // Stubs so the module compiles ahead of the feature build. QA's test
     // suite in commonTest exercises these through FakeAuthRepository until
-    // then. Do not remove the TODO markers without also removing this
-    // comment block.
+    // Backend Builder implements each one for real.
 
     override suspend fun signInWithGoogle(): Result<Unit> =
         TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Google Sign In on KMP")

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
@@ -3,6 +3,17 @@ package org.weekendware.basil.data.repository
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 
+/**
+ * Test double for [AuthRepository]. Owned by QA — configure the `*Result`
+ * properties to drive success/failure paths in ViewModel tests.
+ *
+ * Splash, Auth & Brand Foundation additions (see
+ * `tdd-splash-auth-07222026.md`) are fully implemented here even though the
+ * real [SupabaseAuthRepository] only stubs them — this fake is QA's test
+ * tooling and its behavior is asserted directly in
+ * [FakeAuthRepositoryTest], which also documents the contract Backend
+ * Builder's real implementation must satisfy.
+ */
 class FakeAuthRepository : AuthRepository {
 
     private val _sessionFlow = MutableStateFlow(false)
@@ -10,18 +21,45 @@ class FakeAuthRepository : AuthRepository {
 
     var signInResult: Result<Unit> = Result.success(Unit)
     var signUpResult: Result<Unit> = Result.success(Unit)
+    var googleSignInResult: Result<Unit> = Result.success(Unit)
+    var appleSignInResult: Result<Unit> = Result.success(Unit)
+    var resetPasswordResult: Result<Unit> = Result.success(Unit)
+    var resendVerificationResult: Result<Unit> = Result.success(Unit)
+    var registerPasskeyResult: Result<Unit> = Result.success(Unit)
+    var signInWithPasskeyResult: Result<Unit> = Result.success(Unit)
+    var handleDeepLinkResult: Result<Unit> = Result.success(Unit)
+
+    var emailVerified: Boolean = true
+    var daysSinceSignupValue: Long = 0
+    var passkeyEnrolled: Boolean = false
+    var storedLastUsedEmail: String? = null
+
+    var resetPasswordCallCount: Int = 0
+        private set
+    var resendVerificationCallCount: Int = 0
+        private set
+    var lastResetPasswordEmail: String? = null
+        private set
+    var lastHandledDeepLink: String? = null
+        private set
 
     fun setSignedIn(value: Boolean) {
         _sessionFlow.value = value
     }
 
     override suspend fun signIn(email: String, password: String): Result<Unit> {
-        if (signInResult.isSuccess) _sessionFlow.value = true
+        if (signInResult.isSuccess) {
+            _sessionFlow.value = true
+            storedLastUsedEmail = email
+        }
         return signInResult
     }
 
     override suspend fun signUp(email: String, password: String): Result<Unit> {
-        if (signUpResult.isSuccess) _sessionFlow.value = true
+        if (signUpResult.isSuccess) {
+            _sessionFlow.value = true
+            storedLastUsedEmail = email
+        }
         return signUpResult
     }
 
@@ -33,4 +71,48 @@ class FakeAuthRepository : AuthRepository {
     override fun currentUserId(): String? = if (_sessionFlow.value) "fake-uid" else null
     override fun currentUserEmail(): String? = if (_sessionFlow.value) "fake@example.com" else null
     override fun isSignedIn(): Boolean = _sessionFlow.value
+
+    override suspend fun signInWithGoogle(): Result<Unit> {
+        if (googleSignInResult.isSuccess) _sessionFlow.value = true
+        return googleSignInResult
+    }
+
+    override suspend fun signInWithApple(): Result<Unit> {
+        if (appleSignInResult.isSuccess) _sessionFlow.value = true
+        return appleSignInResult
+    }
+
+    override suspend fun resetPassword(email: String): Result<Unit> {
+        resetPasswordCallCount++
+        lastResetPasswordEmail = email
+        return resetPasswordResult
+    }
+
+    override suspend fun resendVerificationEmail(): Result<Unit> {
+        resendVerificationCallCount++
+        return resendVerificationResult
+    }
+
+    override fun isEmailVerified(): Boolean = emailVerified
+
+    override fun daysSinceSignup(): Long = daysSinceSignupValue
+
+    override suspend fun registerPasskey(): Result<Unit> {
+        if (registerPasskeyResult.isSuccess) passkeyEnrolled = true
+        return registerPasskeyResult
+    }
+
+    override suspend fun signInWithPasskey(): Result<Unit> {
+        if (signInWithPasskeyResult.isSuccess) _sessionFlow.value = true
+        return signInWithPasskeyResult
+    }
+
+    override fun hasPasskeyEnrolled(): Boolean = passkeyEnrolled
+
+    override suspend fun handleDeepLink(url: String): Result<Unit> {
+        lastHandledDeepLink = url
+        return handleDeepLinkResult
+    }
+
+    override fun lastUsedEmail(): String? = storedLastUsedEmail
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
@@ -7,9 +7,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
  * Test double for [AuthRepository]. Owned by QA — configure the `*Result`
  * properties to drive success/failure paths in ViewModel tests.
  *
- * Splash, Auth & Brand Foundation additions (see
- * `tdd-splash-auth-07222026.md`) are fully implemented here even though the
- * real [SupabaseAuthRepository] only stubs them — this fake is QA's test
+ * The social sign-in, password reset, email verification, passkey, and
+ * deep-link methods are fully implemented here even though the real
+ * [SupabaseAuthRepository] only stubs them — this fake is QA's test
  * tooling and its behavior is asserted directly in
  * [FakeAuthRepositoryTest], which also documents the contract Backend
  * Builder's real implementation must satisfy.

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepositoryTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepositoryTest.kt
@@ -1,0 +1,132 @@
+package org.weekendware.basil.data.repository
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Verifies [FakeAuthRepository]'s own contract for the splash-auth
+ * additions. This is QA's test double, not production code, but its
+ * behavior must be trustworthy — a fake that doesn't match the real
+ * contract produces ViewModel tests that pass for the wrong reasons.
+ *
+ * Also serves as executable documentation of what
+ * [SupabaseAuthRepository]'s real implementation must satisfy: success
+ * establishes/updates the relevant state, failure leaves it untouched.
+ */
+class FakeAuthRepositoryTest {
+
+    @Test
+    fun `successful Google sign-in establishes a session`() = runTest {
+        val repo = FakeAuthRepository()
+        val result = repo.signInWithGoogle()
+        assertTrue(result.isSuccess)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `failed Google sign-in does not establish a session`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.googleSignInResult = Result.failure(Exception("cancelled"))
+        val result = repo.signInWithGoogle()
+        assertTrue(result.isFailure)
+        assertFalse(repo.isSignedIn())
+    }
+
+    @Test
+    fun `successful Apple sign-in establishes a session`() = runTest {
+        val repo = FakeAuthRepository()
+        val result = repo.signInWithApple()
+        assertTrue(result.isSuccess)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `resetPassword records the requested email and call count`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.resetPassword("user@example.com")
+        assertEquals(1, repo.resetPasswordCallCount)
+        assertEquals("user@example.com", repo.lastResetPasswordEmail)
+
+        repo.resetPassword("user@example.com")
+        assertEquals(2, repo.resetPasswordCallCount)
+    }
+
+    @Test
+    fun `resendVerificationEmail increments call count independent of result`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.resendVerificationResult = Result.failure(Exception("rate limited"))
+        val result = repo.resendVerificationEmail()
+        assertTrue(result.isFailure)
+        assertEquals(1, repo.resendVerificationCallCount)
+    }
+
+    @Test
+    fun `isEmailVerified and daysSinceSignup reflect configured state`() {
+        val repo = FakeAuthRepository()
+        repo.emailVerified = false
+        repo.daysSinceSignupValue = 31
+        assertFalse(repo.isEmailVerified())
+        assertEquals(31L, repo.daysSinceSignup())
+    }
+
+    @Test
+    fun `successful passkey registration sets hasPasskeyEnrolled`() = runTest {
+        val repo = FakeAuthRepository()
+        assertFalse(repo.hasPasskeyEnrolled())
+        repo.registerPasskey()
+        assertTrue(repo.hasPasskeyEnrolled())
+    }
+
+    @Test
+    fun `failed passkey registration leaves hasPasskeyEnrolled false`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.registerPasskeyResult = Result.failure(Exception("user cancelled"))
+        repo.registerPasskey()
+        assertFalse(repo.hasPasskeyEnrolled())
+    }
+
+    @Test
+    fun `successful passkey sign-in establishes a session`() = runTest {
+        val repo = FakeAuthRepository()
+        val result = repo.signInWithPasskey()
+        assertTrue(result.isSuccess)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `failed passkey sign-in does not establish a session`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.signInWithPasskeyResult = Result.failure(Exception("biometric failed"))
+        val result = repo.signInWithPasskey()
+        assertTrue(result.isFailure)
+        assertFalse(repo.isSignedIn())
+    }
+
+    @Test
+    fun `handleDeepLink records the url and returns the configured result`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.handleDeepLinkResult = Result.failure(Exception("rejected"))
+        val result = repo.handleDeepLink("basil://reset-password?token=abc")
+        assertTrue(result.isFailure)
+        assertEquals("basil://reset-password?token=abc", repo.lastHandledDeepLink)
+    }
+
+    @Test
+    fun `lastUsedEmail is null before any sign-in and set after a successful one`() = runTest {
+        val repo = FakeAuthRepository()
+        assertNull(repo.lastUsedEmail())
+        repo.signIn("returning@example.com", "password123")
+        assertEquals("returning@example.com", repo.lastUsedEmail())
+    }
+
+    @Test
+    fun `lastUsedEmail is set on sign-up as well as sign-in`() = runTest {
+        val repo = FakeAuthRepository()
+        repo.signUp("new@example.com", "password123")
+        assertEquals("new@example.com", repo.lastUsedEmail())
+    }
+}


### PR DESCRIPTION
## Summary
Adds the 11 new `AuthRepository` methods from `tdd-splash-auth-07222026.md` (social sign-in, password reset, email verification, passkeys, deep link handling, detect-by-email) as signatures only.

- `SupabaseAuthRepository` — every new method is `TODO()`. Backend Builder implements these per the TDD.
- `FakeAuthRepository` — fully implemented. Per team process, the Fake is QA's test tooling, not production code, so QA owns it outright (unlike `SupabaseAuthRepository`, which is real production logic and stays Backend's).
- `FakeAuthRepositoryTest` (13 cases, all green) — verifies the fake's own behavior is trustworthy before other suites build on it.

**Deliberately out of scope for this branch:** `SessionState`, `SessionViewModel`, `AuthViewModel`, `AuthScreen`. Extending `SessionState` to carry `isEmailVerified`/`daysSinceSignup` ripples into `App.kt`'s routing `when` and breaks `SplashGateTest`'s existing object-pattern usage of `SessionState.Authenticated`. Rewiring `AuthViewModel` for detect-by-email and passkeys is real Frontend integration work. The TDD itself calls this "the most architecturally significant change" in the feature — better as its own dedicated branch than rushed alongside three other branches today.

## Test plan
- [x] Full existing Android unit test suite (50 tests across 4 suites) — all green, nothing broken by the interface expansion
- [x] `FakeAuthRepositoryTest` — 13/13 green
- [ ] Backend Builder implements `SupabaseAuthRepository`'s 11 stubs