### PR TITLE
Fix: desktopTest fails to compile — missing getAllAsFlow() override

### DIFF
--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }


### PR DESCRIPTION
## Summary
`:composeApp:desktopTest` currently fails to compile on `develop` — `ProfileViewModelTest.kt` defines its own private `FakeUserRepository` that predates `UserRepository.getAllAsFlow()` being added to the interface, and was never updated. This blocks the *entire* desktop test suite, not just this one file.

Found incidentally while verifying an unrelated splash-auth QA branch — unrelated to any feature work, small enough to fix directly rather than just flag.

Backed by `flowOf(getAll())` (a snapshot, not reactive) — no existing test in this file exercises Flow-reactivity, so this is the minimal fix that restores compilation without changing behavior.

## Test plan
- [x] `:composeApp:desktopTest` — full suite compiles and passes