### PR TITLE
QA: extend SessionState with email verification, wire routing

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -57,13 +57,16 @@ import basil.composeapp.generated.resources.nav_profile
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.presentation.auth.AuthScreen
+import org.weekendware.basil.presentation.auth.VerificationWallScreen
 import org.weekendware.basil.presentation.chat.ChatScreen
 import org.weekendware.basil.presentation.more.MoreScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingViewModel
 import org.weekendware.basil.presentation.profile.ProfileScreen
+import org.weekendware.basil.presentation.session.AuthenticatedDestination
 import org.weekendware.basil.presentation.session.SessionState
 import org.weekendware.basil.presentation.session.SessionViewModel
+import org.weekendware.basil.presentation.session.authenticatedDestination
 import org.weekendware.basil.presentation.settings.SettingsScreen
 import org.weekendware.basil.presentation.splash.SplashScreen
 import org.weekendware.basil.presentation.theme.BasilTheme
@@ -104,10 +107,15 @@ fun App() {
                 if (splashVisible) {
                     SplashScreen(onFadeComplete = { splashDone = true })
                 } else {
-                    when (sessionState) {
+                    when (val session = sessionState) {
                         SessionState.Unauthenticated -> AuthScreen()
-                        SessionState.Authenticated   -> AuthenticatedRoot(themeHour = themeHour)
-                        SessionState.Loading         -> Box(Modifier.fillMaxSize())
+                        is SessionState.Authenticated -> when (authenticatedDestination(session)) {
+                            AuthenticatedDestination.Normal ->
+                                AuthenticatedRoot(themeHour = themeHour)
+                            AuthenticatedDestination.VerificationWall ->
+                                VerificationWallScreen()
+                        }
+                        SessionState.Loading -> Box(Modifier.fillMaxSize())
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
@@ -1,0 +1,16 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Shown when a user has gone 30+ days without verifying their email — the
+ * soft-block wall. Blank placeholder pending UI design; Frontend Builder
+ * fills this in with the verify/resend/sign-out content.
+ */
+@Composable
+fun VerificationWallScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize())
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
@@ -13,12 +13,39 @@ sealed interface SessionState {
     /** Supabase is restoring the session from storage — do not navigate yet. */
     data object Loading : SessionState
 
-    /** A valid session exists; the user is signed in. */
-    data object Authenticated : SessionState
+    /**
+     * A valid session exists; the user is signed in.
+     *
+     * @property isEmailVerified True once the user has confirmed their email.
+     * @property daysSinceSignup Elapsed days since account creation — used to
+     *   decide whether an unverified user is inside the grace period or past
+     *   the soft-block threshold.
+     */
+    data class Authenticated(
+        val isEmailVerified: Boolean,
+        val daysSinceSignup: Long,
+    ) : SessionState
 
     /** No session — the user must sign in. */
     data object Unauthenticated : SessionState
 }
+
+/** Where an authenticated user lands once their verification status is known. */
+enum class AuthenticatedDestination { Normal, VerificationWall }
+
+/**
+ * Pure routing decision for an authenticated user. A user unverified for 30
+ * or more days is walled off until they verify or request a new email;
+ * everyone else — verified, or unverified but still within the grace
+ * period — reaches the normal authenticated experience. Unverified-within-grace
+ * users see a dismissible banner inside that experience, not this wall.
+ */
+fun authenticatedDestination(state: SessionState.Authenticated): AuthenticatedDestination =
+    if (!state.isEmailVerified && state.daysSinceSignup >= 30) {
+        AuthenticatedDestination.VerificationWall
+    } else {
+        AuthenticatedDestination.Normal
+    }
 
 /**
  * App-root ViewModel that owns the single source of truth for auth state.
@@ -32,12 +59,19 @@ sealed interface SessionState {
  * the SDK restores a stored session on cold start.
  */
 class SessionViewModel(
-    authRepository: AuthRepository
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     val state: StateFlow<SessionState> = authRepository.sessionFlow
         .map { isSignedIn ->
-            if (isSignedIn) SessionState.Authenticated else SessionState.Unauthenticated
+            if (isSignedIn) {
+                SessionState.Authenticated(
+                    isEmailVerified = authRepository.isEmailVerified(),
+                    daysSinceSignup = authRepository.daysSinceSignup(),
+                )
+            } else {
+                SessionState.Unauthenticated
+            }
         }
         .stateIn(
             scope = viewModelScope,

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
@@ -29,7 +29,7 @@ class SplashGateTest {
     @Test
     fun `shows splash when session resolved but fade not yet complete`() {
         assertTrue(shouldShowSplash(SessionState.Unauthenticated, splashFadeDone = false))
-        assertTrue(shouldShowSplash(SessionState.Authenticated,   splashFadeDone = false))
+        assertTrue(shouldShowSplash(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0),   splashFadeDone = false))
     }
 
     @Test
@@ -39,6 +39,6 @@ class SplashGateTest {
 
     @Test
     fun `hides splash when authenticated and fade is done`() {
-        assertFalse(shouldShowSplash(SessionState.Authenticated, splashFadeDone = true))
+        assertFalse(shouldShowSplash(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0), splashFadeDone = true))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
@@ -1,0 +1,51 @@
+package org.weekendware.basil.presentation.session
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * QA test suite for [authenticatedDestination] — the pure routing decision
+ * that gates the 30-day email-verification soft-block.
+ */
+class SessionStateRoutingTest {
+
+    @Test
+    fun `verified user routes to Normal regardless of account age`() {
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0)),
+        )
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 500)),
+        )
+    }
+
+    @Test
+    fun `unverified user within the grace period routes to Normal`() {
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 0)),
+        )
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 29)),
+        )
+    }
+
+    @Test
+    fun `unverified user at exactly the 30-day boundary routes to the verification wall`() {
+        assertEquals(
+            AuthenticatedDestination.VerificationWall,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 30)),
+        )
+    }
+
+    @Test
+    fun `unverified user well past 30 days routes to the verification wall`() {
+        assertEquals(
+            AuthenticatedDestination.VerificationWall,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 100)),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
@@ -39,7 +39,7 @@ class SessionViewModelTest {
     @Test
     fun `state becomes Authenticated when session flow emits true`() = runTest {
         repo.setSignedIn(true)
-        assertEquals(SessionState.Authenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Authenticated)
     }
 
     @Test
@@ -52,8 +52,32 @@ class SessionViewModelTest {
     @Test
     fun `state reflects sign-out after sign-in`() = runTest {
         repo.setSignedIn(true)
-        assertEquals(SessionState.Authenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Authenticated)
         repo.signOut()
         assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `Authenticated carries the repository's verification status`() = runTest {
+        repo.emailVerified = true
+        repo.daysSinceSignupValue = 5
+        repo.setSignedIn(true)
+
+        assertEquals(
+            SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 5),
+            viewModel.state.value,
+        )
+    }
+
+    @Test
+    fun `Authenticated reflects an unverified user past the 30-day threshold`() = runTest {
+        repo.emailVerified = false
+        repo.daysSinceSignupValue = 31
+        repo.setSignedIn(true)
+
+        assertEquals(
+            SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 31),
+            viewModel.state.value,
+        )
     }
 }


### PR DESCRIPTION
## Summary
Builds on #55 (needs its `AuthRepository.isEmailVerified()`/`daysSinceSignup()` signatures) and merges in #56 (the pre-existing `desktopTest` compile fix, needed to test this branch at all).

- `SessionState.Authenticated` extended from a bare `data object` to carry `isEmailVerified: Boolean` and `daysSinceSignup: Long`.
- `authenticatedDestination()` — new pure routing function (same pattern as the existing `shouldShowSplash()`) implementing the soft-block rule: unverified past 30 days → `VerificationWall`, everyone else → `Normal`.
- `App.kt` routing wired to it; `VerificationWallScreen` added as a blank placeholder (same precedent as the existing `MainApp()` stub) pending UI design.
- `SplashGateTest` and the existing `SessionViewModelTest` updated to compile against the new shape (both QA-owned test files).
- New `SessionStateRoutingTest` (4 cases) and 2 new `SessionViewModelTest` cases covering the verification fields end to end.

## ⚠️ Merge ordering — read before merging (corrected 2026-07-27)
**Do not merge this to `develop` until `SupabaseAuthRepository.isEmailVerified()`/`daysSinceSignup()` are actually implemented.** `SessionViewModel` calls both live on every session-state change — merging before those are real will crash sign-in for every user.

**Correction from an Architect review pass:** this originally pointed at #55 as the fix — wrong. #55 only added the *signatures* as `TODO()` stubs; the real implementations landed 11 PRs later in **#68** (`07272026-native-google-apple-signin`). Numeric-order merging (#52→#69) is **not safe** on its own here: if #57 merges before #68, `develop` sits in the exact crash state this warning describes from the moment #57 lands until #68 does. #68 must merge before or together with #57, not strictly after it in sequence — flag this explicitly during merge planning, don't rely on PR number order.

## Test plan
- [x] Full suite green: 145 tests across 10 suites (`desktopTest` + Android unit test target), including `SplashGateTest` (5/5), `SessionStateRoutingTest` (4/4), `SessionViewModelTest` (6/6)
- [x] `:composeApp:compileDevDebugKotlinAndroid` — clean
- [x] The two `SupabaseAuthRepository` methods this depends on are now implemented — see #68