### PR TITLE
Fix: iOS target fails to compile entirely — Dispatchers.IO is JVM-only

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -23,7 +23,7 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
         database.userQueries.selectAll().executeAsList().map { it.toDomain() }
 
     override fun getAllAsFlow(): Flow<List<User>> =
-        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.IO).map { list ->
+        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.Default).map { list ->
             list.map { it.toDomain() }
         }
 


### PR DESCRIPTION
## Summary
The iOS Simulator target currently fails to compile on \`develop\` — confirmed by cloning \`develop\` fresh into a scratch directory and running \`:composeApp:compileKotlinIosSimulatorArm64\` directly, with no other changes present. Nobody can build or run the iOS app right now.

Root cause: \`SqlDelightUserRepository.kt\` (in \`commonMain\`, shared across all three targets) references \`kotlinx.coroutines.Dispatchers.IO\`, which is a JVM-only API and doesn't exist on Kotlin/Native. Grepped \`commonMain\` for other occurrences — this was the only one.

Fix is \`Dispatchers.Default\` instead, which is available on every KMP target and is the semantically correct choice here regardless of the bug — this dispatcher is used for CPU-bound flow-mapping (SQLDelight query results → domain models), not blocking disk/network IO, so \`Default\` was arguably always the more accurate choice.

Found incidentally while verifying iOS compilation for an unrelated splash-auth branch (deep-link handling touches \`ContentView.swift\`) — unrelated to any feature work, small enough to fix directly rather than just flag.

## Test plan
- [x] \`:composeApp:compileKotlinIosSimulatorArm64\` — clean (was failing before)
- [x] \`:composeApp:compileDevDebugKotlinAndroid\` — clean, no regression
- [x] \`:composeApp:compileKotlinDesktop\` — clean, no regression