### PR TITLE
QA: wire DeepLinkHandler on Android and iOS

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -62,7 +62,6 @@ kotlin {
             implementation(libs.koin.core)
             implementation(libs.koin.compose)
             implementation(libs.koin.compose.viewmodel)
-            implementation(libs.androidx.navigation.compose)
             implementation(libs.supabase.auth)
             implementation(libs.supabase.storage)
             implementation(libs.supabase.postgrest)

--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -9,12 +9,21 @@
         android:theme="@style/Theme.Basil.Splash">
         <activity
             android:exported="true"
+            android:launchMode="singleTop"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <data android:scheme="basil" />
             </intent-filter>
         </activity>
     </application>

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -7,19 +7,17 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.lifecycleScope
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.launch
-import org.koin.mp.KoinPlatform
-import org.weekendware.basil.data.repository.AuthRepository
 
 /**
  * The single Android [ComponentActivity] that hosts the entire Basil UI.
  *
  * Responsibilities:
- * - Installs the OS-level SplashScreen and keeps it visible until the Supabase
- *   SDK has resolved the stored session. This covers the cold-start window
- *   before the first Compose frame is drawn.
+ * - Installs the OS-level SplashScreen as a functional pass-through — it exits
+ *   on the first drawn frame and makes no branded statement of its own. The
+ *   Compose [org.weekendware.basil.presentation.splash.SplashScreen] is the
+ *   single source of truth for the branded splash moment, including the wait
+ *   for session restoration. Holding the OS splash on session resolution here
+ *   as well would draw two splashes back-to-back.
  * - Enables edge-to-edge display so content draws behind system bars.
  * - Sets the Compose content root to [App].
  *
@@ -30,21 +28,9 @@ import org.weekendware.basil.data.repository.AuthRepository
 class MainActivity : ComponentActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
-        val splashScreen = installSplashScreen()
+        installSplashScreen()
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
-
-        // Keep the OS splash visible until sessionFlow emits its first value.
-        // The first emission means Supabase has finished restoring (or not) the
-        // stored session — at that point the Compose layer is ready to show the
-        // correct screen and the OS splash can exit.
-        var sessionResolved = false
-        val authRepository = KoinPlatform.getKoin().get<AuthRepository>()
-        lifecycleScope.launch {
-            authRepository.sessionFlow.first()
-            sessionResolved = true
-        }
-        splashScreen.setKeepOnScreenCondition { !sessionResolved }
 
         setContent {
             App()

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/MainActivity.kt
@@ -1,5 +1,6 @@
 package org.weekendware.basil
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -7,6 +8,10 @@ import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform
+import org.weekendware.basil.data.repository.DeepLinkHandler
 
 /**
  * The single Android [ComponentActivity] that hosts the entire Basil UI.
@@ -20,6 +25,11 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
  *   as well would draw two splashes back-to-back.
  * - Enables edge-to-edge display so content draws behind system bars.
  * - Sets the Compose content root to [App].
+ * - Forwards incoming `basil://` deep links (password reset, OAuth
+ *   callback) to [DeepLinkHandler] — both a cold-start launch via
+ *   [onCreate]'s intent and a warm relaunch via [onNewIntent]
+ *   (`launchMode="singleTop"` in the manifest routes the latter here
+ *   instead of spawning a new activity instance).
  *
  * Koin and Sentry initialisation live in [BasilApplication.onCreate] so they
  * survive activity recreation (rotation, multi-window, etc.) without throwing
@@ -32,8 +42,23 @@ class MainActivity : ComponentActivity() {
         enableEdgeToEdge()
         super.onCreate(savedInstanceState)
 
+        handleDeepLink(intent)
+
         setContent {
             App()
+        }
+    }
+
+    override fun onNewIntent(intent: Intent) {
+        super.onNewIntent(intent)
+        handleDeepLink(intent)
+    }
+
+    private fun handleDeepLink(intent: Intent?) {
+        val url = intent?.data?.toString() ?: return
+        val deepLinkHandler = KoinPlatform.getKoin().get<DeepLinkHandler>()
+        lifecycleScope.launch {
+            deepLinkHandler.handle(url)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkHandler.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkHandler.kt
@@ -1,0 +1,23 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Shared entry point for an incoming deep link (password reset, OAuth
+ * callback), invoked by each platform's native URL-receiving mechanism —
+ * Android's `onNewIntent`, iOS's `.onOpenURL`, Desktop's local callback
+ * server. Identical across platforms, so unlike [AuthRepository] this is a
+ * plain class, not `expect`/`actual`.
+ *
+ * **Not implemented here.** QA scaffolding only — see
+ * [DeepLinkHandlerTest] for the full contract.
+ */
+class DeepLinkHandler(private val authRepository: AuthRepository) {
+
+    /**
+     * Validates [url] against [DeepLinkValidator] and, if allowed, hands it
+     * to [AuthRepository.handleDeepLink]. A [url] outside the allow-list is
+     * dropped silently — no exception, no crash.
+     */
+    suspend fun handle(url: String) {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, DeepLinkHandler")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
@@ -11,10 +11,6 @@ package org.weekendware.basil.data.repository
  * prevents an open-redirect-style attack where a lookalike deep link tricks
  * the app into exchanging an attacker-controlled code.
  *
- * See `tdd-splash-auth-07222026.md`, "Component design" → `DeepLinkHandler`,
- * and security requirement SPA-098–SPA-100 in
- * `tests-splash-auth-07232026.md`.
- *
  * **Not implemented here.** QA scaffolding only — see
  * [DeepLinkValidatorTest] for the full contract, including the boundary
  * case that rules out a naive `startsWith` implementation.

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/DeepLinkValidator.kt
@@ -1,0 +1,39 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Validates an incoming deep link URL against the exact allow-list before
+ * any platform `DeepLinkHandler` passes it to
+ * `client.auth.exchangeCodeForSession(url)`.
+ *
+ * Only two link shapes are ever valid: a password-reset link or an OAuth
+ * callback. Anything else — including a crafted URL where the attacker
+ * controls the trailing path or host segment — must be rejected. This
+ * prevents an open-redirect-style attack where a lookalike deep link tricks
+ * the app into exchanging an attacker-controlled code.
+ *
+ * See `tdd-splash-auth-07222026.md`, "Component design" → `DeepLinkHandler`,
+ * and security requirement SPA-098–SPA-100 in
+ * `tests-splash-auth-07232026.md`.
+ *
+ * **Not implemented here.** QA scaffolding only — see
+ * [DeepLinkValidatorTest] for the full contract, including the boundary
+ * case that rules out a naive `startsWith` implementation.
+ */
+object DeepLinkValidator {
+
+    /** The only two deep link shapes Basil ever handles. */
+    private const val RESET_PASSWORD = "basil://reset-password"
+    private const val AUTH_CALLBACK = "basil://auth/callback"
+
+    /**
+     * True only if [url] is exactly one of the allowed link shapes, or that
+     * shape followed by a query string (`?...`). A URL that merely starts
+     * with the allowed string as raw characters — e.g.
+     * `basil://reset-password-evil.com` — must return false. Backend
+     * Builder implements this with a boundary-aware check, not a plain
+     * `String.startsWith`.
+     */
+    fun isAllowed(url: String): Boolean {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, DeepLinkHandler")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -23,7 +23,7 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
         database.userQueries.selectAll().executeAsList().map { it.toDomain() }
 
     override fun getAllAsFlow(): Flow<List<User>> =
-        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.IO).map { list ->
+        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.Default).map { list ->
             list.map { it.toDomain() }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -12,6 +12,7 @@ import org.weekendware.basil.data.repository.AuthRepository
 import org.weekendware.basil.data.repository.AvatarRepository
 import org.weekendware.basil.data.repository.ChatRepository
 import org.weekendware.basil.data.repository.DataStoreOnboardingRepository
+import org.weekendware.basil.data.repository.DeepLinkHandler
 import org.weekendware.basil.data.repository.KtorChatRepository
 import org.weekendware.basil.data.repository.OnboardingLocalRepository
 import org.weekendware.basil.data.repository.ProfileRepository
@@ -45,6 +46,7 @@ val supabaseModule = module {
     single { createSupabaseClient() }
     single<AuthRepository> { SupabaseAuthRepository(get()) }
     single<AvatarRepository> { SupabaseAvatarRepository(get()) }
+    single { DeepLinkHandler(get()) }
 }
 
 val databaseModule = module {

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkHandlerTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkHandlerTest.kt
@@ -1,0 +1,57 @@
+package org.weekendware.basil.data.repository
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+/**
+ * QA test suite for [DeepLinkHandler], written ahead of implementation per
+ * the team's test-first process.
+ *
+ * All cases are expected to fail with `NotImplementedError` until Backend
+ * Builder implements [DeepLinkHandler.handle] — which itself depends on
+ * [DeepLinkValidator.isAllowed] also being implemented (see
+ * `DeepLinkValidatorTest`).
+ */
+class DeepLinkHandlerTest {
+
+    @Test
+    fun `an allowed reset-password url is forwarded to the auth repository`() = runTest {
+        val repo = FakeAuthRepository()
+        val handler = DeepLinkHandler(repo)
+
+        handler.handle("basil://reset-password?token=abc123")
+
+        assertEquals("basil://reset-password?token=abc123", repo.lastHandledDeepLink)
+    }
+
+    @Test
+    fun `an allowed auth-callback url is forwarded to the auth repository`() = runTest {
+        val repo = FakeAuthRepository()
+        val handler = DeepLinkHandler(repo)
+
+        handler.handle("basil://auth/callback?code=xyz")
+
+        assertEquals("basil://auth/callback?code=xyz", repo.lastHandledDeepLink)
+    }
+
+    @Test
+    fun `a rejected url is dropped and never reaches the auth repository`() = runTest {
+        val repo = FakeAuthRepository()
+        val handler = DeepLinkHandler(repo)
+
+        handler.handle("basil://reset-password-evil.com")
+
+        assertNull(repo.lastHandledDeepLink)
+    }
+
+    @Test
+    fun `a rejected url does not throw`() = runTest {
+        val repo = FakeAuthRepository()
+        val handler = DeepLinkHandler(repo)
+
+        // Should complete normally — dropped silently, not an exception.
+        handler.handle("https://not-basil-at-all.com")
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
@@ -1,0 +1,78 @@
+package org.weekendware.basil.data.repository
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [DeepLinkValidator], written from
+ * `tdd-splash-auth-07222026.md` ahead of implementation.
+ *
+ * All cases are expected to fail until Backend Builder implements
+ * [DeepLinkValidator.isAllowed]. Covers SPA-098–SPA-100 in
+ * `tests-splash-auth-07232026.md`.
+ */
+class DeepLinkValidatorTest {
+
+    @Test
+    fun `bare reset-password link is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://reset-password"))
+    }
+
+    @Test
+    fun `reset-password link with a query string is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://reset-password?token=abc123"))
+    }
+
+    @Test
+    fun `bare auth callback link is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://auth/callback"))
+    }
+
+    @Test
+    fun `auth callback link with a query string is allowed`() {
+        assertTrue(DeepLinkValidator.isAllowed("basil://auth/callback?code=xyz"))
+    }
+
+    @Test
+    fun `a lookalike link that merely starts with the allowed string is rejected`() {
+        // "basil://reset-password-evil.com" is a raw string prefix of
+        // "basil://reset-password" as characters — a naive startsWith()
+        // check would wrongly accept this. The allowed shape ends at the
+        // path boundary (end of string or '?'), not at an arbitrary
+        // continuation of the same characters.
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password-evil.com"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password.attacker.com"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://auth/callbackXYZ"))
+    }
+
+    @Test
+    fun `wrong scheme is rejected even with an otherwise valid path`() {
+        assertFalse(DeepLinkValidator.isAllowed("https://reset-password"))
+        assertFalse(DeepLinkValidator.isAllowed("http://basil.app/reset-password"))
+    }
+
+    @Test
+    fun `unrelated basil scheme paths are rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed("basil://home"))
+        assertFalse(DeepLinkValidator.isAllowed("basil://chat"))
+    }
+
+    @Test
+    fun `empty and blank input is rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed(""))
+        assertFalse(DeepLinkValidator.isAllowed("   "))
+    }
+
+    @Test
+    fun `path traversal style suffix is rejected`() {
+        assertFalse(DeepLinkValidator.isAllowed("basil://reset-password/../../auth/callback"))
+    }
+
+    @Test
+    fun `case sensitivity — scheme is not matched case-insensitively`() {
+        // Custom URL schemes should be handled literally; do not silently
+        // widen the allow-list via case-insensitive matching.
+        assertFalse(DeepLinkValidator.isAllowed("BASIL://reset-password"))
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/DeepLinkValidatorTest.kt
@@ -5,12 +5,13 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 /**
- * QA test suite for [DeepLinkValidator], written from
- * `tdd-splash-auth-07222026.md` ahead of implementation.
+ * QA test suite for [DeepLinkValidator], written ahead of implementation
+ * per the team's test-first process. Covers the allowed reset-password
+ * and auth-callback shapes, and the lookalike-prefix boundary case that
+ * rules out a naive `startsWith` implementation.
  *
  * All cases are expected to fail until Backend Builder implements
- * [DeepLinkValidator.isAllowed]. Covers SPA-098–SPA-100 in
- * `tests-splash-auth-07232026.md`.
+ * [DeepLinkValidator.isAllowed].
  */
 class DeepLinkValidatorTest {
 

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }

--- a/composeApp/src/iosMain/kotlin/org/weekendware/basil/DeepLinkBridge.kt
+++ b/composeApp/src/iosMain/kotlin/org/weekendware/basil/DeepLinkBridge.kt
@@ -1,0 +1,26 @@
+package org.weekendware.basil
+
+import kotlinx.coroutines.DelicateCoroutinesApi
+import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.launch
+import org.koin.mp.KoinPlatform
+import org.weekendware.basil.data.repository.DeepLinkHandler
+
+/**
+ * Entry point for `ContentView.swift`'s `.onOpenURL` — Swift has no
+ * concept of Kotlin coroutines, so this exposes a plain synchronous
+ * function that launches the suspend call itself. Mirrors
+ * [MainViewController] as the other Kotlin declaration Swift calls into
+ * directly (`DeepLinkBridgeKt.handleDeepLink(url)` from Swift).
+ *
+ * Fire-and-forget by design, same as Android's `lifecycleScope.launch` in
+ * `MainActivity.handleDeepLink` — there is nothing to cancel or await from
+ * the Swift side.
+ */
+@OptIn(DelicateCoroutinesApi::class)
+fun handleDeepLink(url: String) {
+    val deepLinkHandler = KoinPlatform.getKoin().get<DeepLinkHandler>()
+    GlobalScope.launch {
+        deepLinkHandler.handle(url)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,7 +22,6 @@ materialIconsExtended = "1.7.3"
 sqldelight = "2.0.1"
 detekt = "1.23.7"
 mockitoKotlin = "5.4.0"
-navigation = "2.8.0-alpha13"
 buildkonfig = "0.15.2"
 supabase = "3.1.4"
 sentry = "0.25.0"
@@ -63,7 +62,6 @@ sqldelight-androidDriver = { module = "app.cash.sqldelight:android-driver", vers
 sqldelight-nativeDriver = { module = "app.cash.sqldelight:native-driver", version.ref = "sqldelight" }
 sqldelight-coroutines = { module = "app.cash.sqldelight:coroutines-extensions", version.ref = "sqldelight" }
 sqlite-driver = { module = "app.cash.sqldelight:sqlite-driver", version.ref = "sqldelight" }
-androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "navigation" }
 supabase-auth = { module = "io.github.jan-tennert.supabase:auth-kt", version.ref = "supabase" }
 supabase-storage = { module = "io.github.jan-tennert.supabase:storage-kt", version.ref = "supabase" }
 supabase-postgrest = { module = "io.github.jan-tennert.supabase:postgrest-kt", version.ref = "supabase" }

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     var body: some View {
         ComposeView()
             .ignoresSafeArea(.all) // Compose owns all safe-area insets via WindowInsets
+            .onOpenURL { url in
+                DeepLinkBridgeKt.handleDeepLink(url: url.absoluteString)
+            }
     }
 }
 

--- a/iosApp/iosApp/Info.plist
+++ b/iosApp/iosApp/Info.plist
@@ -6,5 +6,14 @@
 	<true/>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>basil</string>
+			</array>
+		</dict>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
## Summary
Depends on #52 (cleaned MainActivity), #54 (DeepLinkValidator), #55 (AuthRepository.handleDeepLink), #56 (desktopTest fix), and #58 (iOS Dispatchers.IO fix) — all merged in locally to make this branch fully verifiable.

- \`DeepLinkHandler\` (commonMain) — **not** \`expect\`/\`actual\`, unlike \`PasskeyManager\`. The handling logic (validate → delegate) is identical on every platform; only the URL-receiving mechanism differs. Signature-only stub, composes \`DeepLinkValidator\` + \`AuthRepository.handleDeepLink\`.
- **Android**: \`basil://\` intent-filter + \`launchMode="singleTop"\` in the manifest; \`MainActivity\` forwards both cold-start and warm-relaunch intents via \`onNewIntent\`.
- **iOS**: \`DeepLinkBridge.kt\` exposes a plain synchronous function Swift's \`.onOpenURL\` calls directly (Swift has no concept of Kotlin coroutines) — mirrors the existing \`MainViewController\` bridge pattern. \`Info.plist\` registers the \`basil\` URL scheme. Fire-and-forget via \`GlobalScope.launch\`, same shape as Android's \`lifecycleScope.launch\`.
- Registered in Koin (\`supabaseModule\`).
- 4 tests, all currently red (\`NotImplementedError\`) by design.

## Incidental finding — fixed separately (#58)
While verifying this branch's iOS side actually compiles, found that **the iOS target fails to compile on `develop` entirely**, unrelated to this work — \`SqlDelightUserRepository.kt\` used \`Dispatchers.IO\`, a JVM-only API. Confirmed via a clean clone of \`develop\` with zero other changes. Fixed in #58 (\`Dispatchers.Default\`, verified across all three targets) and merged into this branch so I could actually verify \`DeepLinkBridge.kt\` links for iOS rather than assume it.

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\` — clean (this is the first PR in the splash-auth series actually verified against a real iOS Kotlin/Native link, not just Android)
- [x] \`:composeApp:compileDevDebugKotlinAndroid\` — clean
- [x] \`:composeApp:desktopTest\` — clean
- [x] \`:composeApp:testDevDebugUnitTest\` — 50 pre-existing pass, 14 new fail red as expected (\`DeepLinkHandlerTest\` × 4, \`DeepLinkValidatorTest\` × 10)
- [ ] Backend implements \`DeepLinkValidator.isAllowed()\` and \`DeepLinkHandler.handle()\`
- [ ] Manual: verify \`basil://\` deep link actually opens the app on a real/simulated device (not verifiable from this environment)