### PR TITLE
QA: PasskeyManager expect/actual scaffold for FIDO2 ceremonies

### DIFF
--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
@@ -1,0 +1,22 @@
+package org.weekendware.basil.data.repository
+
+import android.content.Context
+
+/**
+ * Android FIDO2 ceremony execution via `androidx.credentials.CredentialManager`.
+ *
+ * Registration: `CredentialManager.createCredential(CreatePublicKeyCredentialRequest)`.
+ * Authentication: `CredentialManager.getCredential(GetPublicKeyCredentialOption)`.
+ * Requires `androidx.credentials:credentials` and
+ * `androidx.credentials:credentials-play-services-auth`.
+ */
+actual class PasskeyManager(private val context: Context) {
+
+    actual suspend fun createCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (Android)")
+    }
+
+    actual suspend fun getCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (Android)")
+    }
+}

--- a/composeApp/src/androidMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
+++ b/composeApp/src/androidMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
@@ -9,10 +9,12 @@ import org.weekendware.basil.data.local.ONBOARDING_DATASTORE_FILE
 import org.weekendware.basil.data.local.createOnboardingDataStore
 import org.weekendware.basil.data.local.database.DatabaseDriverFactory
 import org.weekendware.basil.data.local.database.DatabaseKeyProvider
+import org.weekendware.basil.data.repository.PasskeyManager
 
 actual val platformModule: Module = module {
     single { DatabaseKeyProvider(get<Context>()) }
     single { DatabaseDriverFactory(get<Context>(), get()) }
+    single { PasskeyManager(get<Context>()) }
     single<DataStore<Preferences>> {
         val context = get<Context>()
         createOnboardingDataStore(context.filesDir.resolve(ONBOARDING_DATASTORE_FILE).absolutePath)

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
@@ -1,0 +1,35 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Executes FIDO2 passkey registration and authentication ceremonies using
+ * each platform's native credential store. Given a WebAuthn challenge from
+ * Supabase, produces the attestation (registration) or assertion
+ * (authentication) needed to complete the round trip.
+ *
+ * Fetching the challenge and posting the result back to Supabase is
+ * [AuthRepository]'s job, not this class's — [PasskeyManager] only executes
+ * the platform credential ceremony in between. The credential's private key
+ * never leaves the platform secure store (iCloud Keychain / Google Password
+ * Manager); this class only ever handles the public attestation/assertion.
+ *
+ * **Not implemented here.** QA scaffolding only — see [PasskeyManagerTest]
+ * for the Desktop no-op contract, the only platform behavior specified
+ * precisely enough to verify without a real device, simulator, or platform
+ * credential UI.
+ */
+expect class PasskeyManager {
+
+    /**
+     * Creates a new passkey credential from [challengeJson] (a FIDO2
+     * `PublicKeyCredentialCreationOptions` challenge) and returns the
+     * resulting attestation as JSON.
+     */
+    suspend fun createCredential(challengeJson: String): Result<String>
+
+    /**
+     * Signs [challengeJson] (a FIDO2 `PublicKeyCredentialRequestOptions`
+     * challenge) with the platform-stored private key and returns the
+     * resulting assertion as JSON.
+     */
+    suspend fun getCredential(challengeJson: String): Result<String>
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -23,7 +23,7 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
         database.userQueries.selectAll().executeAsList().map { it.toDomain() }
 
     override fun getAllAsFlow(): Flow<List<User>> =
-        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.IO).map { list ->
+        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.Default).map { list ->
             list.map { it.toDomain() }
         }
 

--- a/composeApp/src/desktopMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
+++ b/composeApp/src/desktopMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
@@ -1,0 +1,18 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * Desktop has no platform credential store, so passkeys aren't supported
+ * here — both operations always fail. The passkey enrolment prompt and
+ * adaptive biometric auth screen are never shown on Desktop; email/password
+ * and Google OAuth remain the only sign-in paths.
+ */
+actual class PasskeyManager {
+
+    actual suspend fun createCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (Desktop no-op)")
+    }
+
+    actual suspend fun getCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (Desktop no-op)")
+    }
+}

--- a/composeApp/src/desktopMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
+++ b/composeApp/src/desktopMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
@@ -7,9 +7,11 @@ import org.koin.dsl.module
 import org.weekendware.basil.data.local.ONBOARDING_DATASTORE_FILE
 import org.weekendware.basil.data.local.createOnboardingDataStore
 import org.weekendware.basil.data.local.database.DatabaseDriverFactory
+import org.weekendware.basil.data.repository.PasskeyManager
 
 actual val platformModule: Module = module {
     single { DatabaseDriverFactory() }
+    single { PasskeyManager() }
     single<DataStore<Preferences>> {
         val dir = System.getProperty("user.home") + "/.basil"
         java.io.File(dir).mkdirs()

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/PasskeyManagerTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/data/repository/PasskeyManagerTest.kt
@@ -1,0 +1,36 @@
+package org.weekendware.basil.data.repository
+
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for the Desktop [PasskeyManager] — the only platform whose
+ * behavior (unsupported, always fails) is specified precisely enough to
+ * verify without real hardware, a simulator, or platform credential UI.
+ * Android and iOS ceremonies need platform-specific test infrastructure
+ * (Robolectric-style `CredentialManager` mocking, XCTest) that doesn't
+ * exist in this project yet — flagged as a follow-up, not written here.
+ *
+ * Both cases are expected to fail until Backend Builder implements the
+ * Desktop no-op per the TDD (`Result.failure(UnsupportedOperationException)`).
+ */
+class PasskeyManagerTest {
+
+    @Test
+    fun `createCredential is unsupported on Desktop`() = runTest {
+        val manager = PasskeyManager()
+        val result = manager.createCredential("{}")
+        assertTrue(result.isFailure)
+        assertIs<UnsupportedOperationException>(result.exceptionOrNull())
+    }
+
+    @Test
+    fun `getCredential is unsupported on Desktop`() = runTest {
+        val manager = PasskeyManager()
+        val result = manager.getCredential("{}")
+        assertTrue(result.isFailure)
+        assertIs<UnsupportedOperationException>(result.exceptionOrNull())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }

--- a/composeApp/src/iosMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
+++ b/composeApp/src/iosMain/kotlin/org/weekendware/basil/data/repository/PasskeyManager.kt
@@ -1,0 +1,25 @@
+package org.weekendware.basil.data.repository
+
+/**
+ * iOS FIDO2 ceremony execution via
+ * `ASAuthorizationPlatformPublicKeyCredentialProvider` (AuthenticationServices,
+ * iOS 16+).
+ *
+ * Registration: `ASAuthorizationPlatformPublicKeyCredentialRegistrationRequest`.
+ * Authentication: `ASAuthorizationPlatformPublicKeyCredentialAssertionRequest`.
+ * `AuthenticationServices` isn't wrapped by any KMP library at the
+ * supabase-kt version this project uses — the real implementation needs a
+ * `kotlinx-cinterop` binding and `@ObjCAction` delegate callbacks wrapped in
+ * `suspendCoroutine`. Highest-risk implementation task in the passkey
+ * feature; allocate extra time.
+ */
+actual class PasskeyManager {
+
+    actual suspend fun createCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (iOS)")
+    }
+
+    actual suspend fun getCredential(challengeJson: String): Result<String> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Passkeys on KMP (iOS)")
+    }
+}

--- a/composeApp/src/iosMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
+++ b/composeApp/src/iosMain/kotlin/org/weekendware/basil/di/PlatformModule.kt
@@ -8,11 +8,13 @@ import org.weekendware.basil.data.local.ONBOARDING_DATASTORE_FILE
 import org.weekendware.basil.data.local.createOnboardingDataStore
 import org.weekendware.basil.data.local.database.DatabaseDriverFactory
 import org.weekendware.basil.data.local.database.DatabaseKeyProvider
+import org.weekendware.basil.data.repository.PasskeyManager
 import platform.Foundation.NSHomeDirectory
 
 actual val platformModule: Module = module {
     single { DatabaseKeyProvider() }
     single { DatabaseDriverFactory(get()) }
+    single { PasskeyManager() }
     single<DataStore<Preferences>> {
         createOnboardingDataStore("${NSHomeDirectory()}/Documents/$ONBOARDING_DATASTORE_FILE")
     }


### PR DESCRIPTION
## Summary
Depends on #58 (iOS Dispatchers.IO fix) and #56 (desktopTest fix) — merged in locally for testability. This is the last piece from the TDD's implementation sequence I'm scaffolding in this pass.

- \`PasskeyManager\` — \`expect\`/\`actual\`, one implementation per platform. Executes the FIDO2 ceremony only; fetching the WebAuthn challenge and posting the result stays \`AuthRepository\`'s job.
- All three actuals (Android, iOS, Desktop) are \`TODO()\` stubs. **Including Desktop's**, even though the TDD fully specifies it as a trivial deterministic no-op (\`Result.failure(UnsupportedOperationException)\`) — kept consistent with how #53 and #54 scaffolded PasswordStrengthValidator and DeepLinkValidator (both also fully-specified, both left to Backend). QA doesn't implement production logic regardless of how trivial it is.
- Wired into each platform's \`platformModule\` via Koin, matching the existing \`DatabaseKeyProvider\` pattern (Android needs \`Context\`, iOS/Desktop don't).

## Test coverage gap — flagged, not silently skipped
\`PasskeyManagerTest\` (desktopTest) only covers the Desktop no-op — the one platform behavior specified precisely enough to verify without real hardware, a simulator, or platform credential UI. Android's \`CredentialManager\` and iOS's \`AuthenticationServices\` ceremonies need platform-specific test infrastructure (Robolectric-style mocking for Android, XCTest for iOS) that doesn't exist in this project yet. Writing tests against those without real mocking infra would just be theater — flagging as a follow-up for whoever sets that up alongside the real implementation, per the TDD's own test strategy table (\`PasskeyManagerTest\`: "registration ceremony sends attestation; authentication ceremony sends assertion; Desktop returns UnsupportedOperationException").

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\` — clean
- [x] \`:composeApp:compileDevDebugKotlinAndroid\` — clean
- [x] \`:composeApp:desktopTest\` + \`:composeApp:testDevDebugUnitTest\` — 128 tests total, 2 fail red as expected (the new \`PasskeyManagerTest\` Desktop cases), nothing else regressed
- [ ] Backend implements Desktop's no-op (trivial) and the Android/iOS real ceremonies (highest-risk task in the feature — cinterop on iOS)
- [ ] Android/iOS test infrastructure set up alongside real implementation