### PR TITLE
Rewrite auth screen: email-first detect-by-email, matching UI Designer mockup

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -7,16 +7,24 @@
     <string name="app_type1_label">Type 1 Diabetes</string>
 
     <!-- ── Auth screen ───────────────────────────────────────── -->
-    <string name="auth_create_account">Create account</string>
+    <string name="auth_tagline">For Type 1 Diabetes</string>
+    <string name="auth_continue">Continue</string>
+    <string name="auth_continue_with_apple">Continue with Apple</string>
+    <string name="auth_continue_with_google">Continue with Google</string>
+    <string name="auth_or">or</string>
     <string name="auth_welcome_back">Welcome back</string>
-    <string name="auth_signup_subtitle">Sign up to meet Basil.</string>
-    <string name="auth_signin_subtitle">Sign in to continue to Basil.</string>
+    <string name="auth_signin_subtitle">Sign in to continue.</string>
     <string name="auth_field_email">Email</string>
     <string name="auth_field_password">Password</string>
-    <string name="auth_email_placeholder">you@example.com</string>
     <string name="auth_sign_in">Sign in</string>
-    <string name="auth_toggle_to_signup">New to Basil? Create account</string>
-    <string name="auth_toggle_to_signin">Already have an account? Sign in</string>
+    <string name="auth_forgot_password">Forgot password?</string>
+    <string name="auth_use_different_account">Use a different account</string>
+    <string name="auth_no_account_title">No account found</string>
+    <string name="auth_no_account_body">Start the conversation to create one. It only takes a minute.</string>
+    <string name="auth_get_started">Get started</string>
+    <string name="auth_try_different_email">Try a different email</string>
+    <string name="cd_show_password">Show password</string>
+    <string name="cd_hide_password">Hide password</string>
 
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -23,7 +23,7 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
         database.userQueries.selectAll().executeAsList().map { it.toDomain() }
 
     override fun getAllAsFlow(): Flow<List<User>> =
-        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.IO).map { list ->
+        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.Default).map { list ->
             list.map { it.toDomain() }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
@@ -131,7 +131,7 @@ fun AuthScreenContent(
             .fillMaxSize()
             .background(BasilPalette.Cream)
     ) {
-        AuthHeroBand(compact = !state.emailStep)
+        AuthHeroBand(showTagline = state.emailStep)
         if (state.emailStep) {
             EmailStepForm(
                 state           = state,
@@ -157,41 +157,31 @@ fun AuthScreenContent(
     }
 }
 
+/**
+ * The hero band is always the full column layout (52dp logo, 28sp wordmark)
+ * on every step of this screen — email, sign-in, and no-account-found alike.
+ * Only the tagline is conditional: shown on the email step, hidden once the
+ * user has moved past it. There is no separate "compact" row variant here —
+ * that belongs to [ResetPasswordScreen]'s distinct mini-header.
+ */
 @Composable
-private fun AuthHeroBand(compact: Boolean) {
-    if (compact) {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(BasilPalette.Sage600)
-                .statusBarsPadding()
-                .padding(vertical = 16.dp, horizontal = 20.dp),
-            verticalAlignment = Alignment.CenterVertically,
-        ) {
-            AuthLogoPlaceholder()
-            Spacer(Modifier.width(12.dp))
-            Text(
-                text  = stringResource(Res.string.app_name),
-                style = MaterialTheme.typography.headlineSmall,
-                color = Color.White,
-            )
-        }
-    } else {
-        Column(
-            modifier = Modifier
-                .fillMaxWidth()
-                .background(BasilPalette.Sage600)
-                .statusBarsPadding()
-                .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 24.dp),
-            horizontalAlignment = Alignment.CenterHorizontally,
-        ) {
-            AuthLogoPlaceholder()
-            Spacer(Modifier.height(8.dp))
-            Text(
-                text  = stringResource(Res.string.app_name),
-                style = MaterialTheme.typography.displaySmall,
-                color = Color.White,
-            )
+private fun AuthHeroBand(showTagline: Boolean) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BasilPalette.Sage600)
+            .statusBarsPadding()
+            .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        AuthLogoPlaceholder()
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text  = stringResource(Res.string.app_name),
+            style = MaterialTheme.typography.displaySmall,
+            color = Color.White,
+        )
+        if (showTagline) {
             Spacer(Modifier.height(8.dp))
             Text(
                 text          = stringResource(Res.string.auth_tagline).uppercase(),

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
@@ -1,56 +1,79 @@
 package org.weekendware.basil.presentation.auth
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import basil.composeapp.generated.resources.Res
 import basil.composeapp.generated.resources.app_name
-import basil.composeapp.generated.resources.app_tagline
-import basil.composeapp.generated.resources.auth_create_account
-import basil.composeapp.generated.resources.auth_email_placeholder
+import basil.composeapp.generated.resources.auth_continue
+import basil.composeapp.generated.resources.auth_continue_with_apple
+import basil.composeapp.generated.resources.auth_continue_with_google
 import basil.composeapp.generated.resources.auth_field_email
 import basil.composeapp.generated.resources.auth_field_password
+import basil.composeapp.generated.resources.auth_forgot_password
+import basil.composeapp.generated.resources.auth_get_started
+import basil.composeapp.generated.resources.auth_no_account_body
+import basil.composeapp.generated.resources.auth_no_account_title
+import basil.composeapp.generated.resources.auth_or
 import basil.composeapp.generated.resources.auth_sign_in
 import basil.composeapp.generated.resources.auth_signin_subtitle
-import basil.composeapp.generated.resources.auth_signup_subtitle
-import basil.composeapp.generated.resources.auth_toggle_to_signin
-import basil.composeapp.generated.resources.auth_toggle_to_signup
+import basil.composeapp.generated.resources.auth_tagline
+import basil.composeapp.generated.resources.auth_try_different_email
+import basil.composeapp.generated.resources.auth_use_different_account
 import basil.composeapp.generated.resources.auth_welcome_back
+import basil.composeapp.generated.resources.cd_hide_password
+import basil.composeapp.generated.resources.cd_show_password
 import basil.composeapp.generated.resources.error_auth_failed
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
-import org.weekendware.basil.presentation.components.BasilLeaf
 import org.weekendware.basil.presentation.theme.BasilPalette
 import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.BasilTokens
@@ -59,141 +82,235 @@ import org.weekendware.basil.presentation.theme.BasilTokens
  * Authentication screen, shown when no valid session exists.
  *
  * Wires [AuthViewModel] to [AuthScreenContent]. Navigation away from this
- * screen happens automatically when [SessionViewModel] detects a successful
- * authentication.
+ * screen happens automatically when [org.weekendware.basil.presentation.session.SessionViewModel]
+ * detects a successful authentication.
+ *
+ * @param onGetStarted Called when a user with no recognized account taps
+ *   "Get started" on the no-account-found state. Currently a no-op by
+ *   default — the full silent-account-provisioning redirect into
+ *   onboarding is separate, not-yet-wired routing work.
  */
 @Composable
-fun AuthScreen() {
+fun AuthScreen(onGetStarted: () -> Unit = {}) {
     val viewModel = koinViewModel<AuthViewModel>()
     val state by viewModel.state.collectAsStateWithLifecycle()
     AuthScreenContent(
-        state           = state,
-        onEmailChange   = viewModel::onEmailChange,
-        onPasswordChange = viewModel::onPasswordChange,
-        onToggle        = viewModel::toggleMode,
-        onSubmit        = viewModel::submit
+        state                       = state,
+        onEmailChange               = viewModel::onEmailChange,
+        onPasswordChange            = viewModel::onPasswordChange,
+        onTogglePasswordVisibility  = viewModel::onTogglePasswordVisibility,
+        onContinueEmail             = viewModel::onContinueEmail,
+        onUseDifferentAccount       = viewModel::onUseDifferentAccount,
+        onSubmit                    = viewModel::submit,
+        onGoogleSignIn              = viewModel::onGoogleSignIn,
+        onAppleSignIn               = viewModel::onAppleSignIn,
+        onGetStarted                = onGetStarted,
     )
 }
 
 /**
- * Stateless authentication UI.
- *
- * Layout matches the "Option A — Warm & Grounded" design handoff:
- * - Sage-600 hero band with the leaf mark + "basil" wordmark
- * - Cream background form area below with email/password fields
- *
- * @param state            Current form state.
- * @param onEmailChange    Called when the email field changes.
- * @param onPasswordChange Called when the password field changes.
- * @param onToggle         Called when the sign-in / sign-up toggle is tapped.
- * @param onSubmit         Called when the submit button is tapped.
+ * Stateless authentication UI: an email-first step, then either a sign-in
+ * password step (account recognized) or a no-account-found state, per the
+ * approved UI Designer mockup.
  */
 @Composable
 fun AuthScreenContent(
-    state:            AuthFormState,
-    onEmailChange:    (String) -> Unit,
-    onPasswordChange: (String) -> Unit,
-    onToggle:         () -> Unit,
-    onSubmit:         () -> Unit
+    state:                      AuthUiState,
+    onEmailChange:               (String) -> Unit,
+    onPasswordChange:            (String) -> Unit,
+    onTogglePasswordVisibility:  () -> Unit,
+    onContinueEmail:              () -> Unit,
+    onUseDifferentAccount:        () -> Unit,
+    onSubmit:                     () -> Unit,
+    onGoogleSignIn:                () -> Unit,
+    onAppleSignIn:                 () -> Unit,
+    onGetStarted:                  () -> Unit,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .background(BasilPalette.Cream)
     ) {
-        AuthHeroBand()
-        AuthForm(
-            state            = state,
-            onEmailChange    = onEmailChange,
-            onPasswordChange = onPasswordChange,
-            onToggle         = onToggle,
-            onSubmit         = onSubmit
-        )
-    }
-}
-
-@Composable
-private fun AuthHeroBand() {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .background(
-                color = BasilPalette.Sage600,
-                shape = RoundedCornerShape(
-                    bottomStart = BasilTokens.AuthHeroCorner,
-                    bottomEnd   = BasilTokens.AuthHeroCorner
-                )
+        AuthHeroBand(compact = !state.emailStep)
+        if (state.emailStep) {
+            EmailStepForm(
+                state           = state,
+                onEmailChange   = onEmailChange,
+                onContinueEmail = onContinueEmail,
+                onGoogleSignIn  = onGoogleSignIn,
+                onAppleSignIn   = onAppleSignIn,
             )
-            .statusBarsPadding()
-            .padding(top = 48.dp, bottom = 36.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
+        } else when (state.mode) {
+            AuthMode.SignIn -> SignInForm(
+                state                      = state,
+                onPasswordChange           = onPasswordChange,
+                onTogglePasswordVisibility = onTogglePasswordVisibility,
+                onUseDifferentAccount      = onUseDifferentAccount,
+                onSubmit                   = onSubmit,
+            )
+            AuthMode.SignUp -> NoAccountFound(
+                email                 = state.email,
+                onUseDifferentAccount = onUseDifferentAccount,
+                onGetStarted          = onGetStarted,
+            )
+        }
+    }
+}
+
+@Composable
+private fun AuthHeroBand(compact: Boolean) {
+    if (compact) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BasilPalette.Sage600)
+                .statusBarsPadding()
+                .padding(vertical = 16.dp, horizontal = 20.dp),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            AuthLogoPlaceholder()
+            Spacer(Modifier.width(12.dp))
+            Text(
+                text  = stringResource(Res.string.app_name),
+                style = MaterialTheme.typography.headlineSmall,
+                color = Color.White,
+            )
+        }
+    } else {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BasilPalette.Sage600)
+                .statusBarsPadding()
+                .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            AuthLogoPlaceholder()
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text  = stringResource(Res.string.app_name),
+                style = MaterialTheme.typography.displaySmall,
+                color = Color.White,
+            )
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text          = stringResource(Res.string.auth_tagline).uppercase(),
+                style         = MaterialTheme.typography.labelSmall,
+                color         = Color.White.copy(alpha = 0.55f),
+                letterSpacing = 1.5.sp,
+            )
+        }
+    }
+}
+
+/** Logo placeholder — final mark pending Design; a lettered square, not the splash [BasilLeaf]. */
+@Composable
+private fun AuthLogoPlaceholder() {
+    Box(
+        modifier = Modifier
+            .size(BasilTokens.AuthLogoSize)
+            .clip(RoundedCornerShape(BasilTokens.AuthLogoCorner))
+            .background(Color.White.copy(alpha = 0.15f)),
+        contentAlignment = Alignment.Center,
     ) {
-        BasilLeaf(size = BasilTokens.AuthHeroLeafSize, fill = Color.White, vein = BasilPalette.Sage800)
-        Spacer(Modifier.height(10.dp))
         Text(
-            text  = stringResource(Res.string.app_name),
-            style = MaterialTheme.typography.displaySmall,
-            color = Color.White
-        )
-        Spacer(Modifier.height(4.dp))
-        Text(
-            text  = stringResource(Res.string.app_tagline),
-            style = MaterialTheme.typography.bodyMedium,
-            color = Color.White.copy(alpha = 0.6f)
+            text  = "b",
+            style = MaterialTheme.typography.headlineMedium,
+            color = Color.White,
         )
     }
 }
 
 @Composable
-private fun AuthForm(
-    state:            AuthFormState,
+private fun EmailStepForm(
+    state:            AuthUiState,
     onEmailChange:    (String) -> Unit,
-    onPasswordChange: (String) -> Unit,
-    onToggle:         () -> Unit,
-    onSubmit:         () -> Unit
+    onContinueEmail:  () -> Unit,
+    onGoogleSignIn:   () -> Unit,
+    onAppleSignIn:    () -> Unit,
 ) {
     Column(
         modifier = Modifier
             .fillMaxSize()
             .verticalScroll(rememberScrollState())
-            .padding(horizontal = 24.dp, vertical = 28.dp)
+            .padding(horizontal = 20.dp)
+            .padding(top = 24.dp, bottom = 28.dp),
     ) {
-        val title = if (state.isSignUp) {
-            stringResource(Res.string.auth_create_account)
-        } else {
-            stringResource(Res.string.auth_welcome_back)
-        }
-        Text(
-            text  = title,
-            style = MaterialTheme.typography.headlineSmall,
-            color = BasilPalette.Stone900
+        Spacer(Modifier.height(8.dp))
+        SocialButton(
+            label      = stringResource(Res.string.auth_continue_with_apple),
+            background = BasilPalette.Black,
+            textColor  = Color.White,
+            onClick    = onAppleSignIn,
         )
-        Spacer(Modifier.height(4.dp))
-        val subtitle = if (state.isSignUp) {
-            stringResource(Res.string.auth_signup_subtitle)
-        } else {
-            stringResource(Res.string.auth_signin_subtitle)
-        }
-        Text(
-            text  = subtitle,
-            style = MaterialTheme.typography.bodyMedium,
-            color = BasilPalette.Stone500
+        Spacer(Modifier.height(10.dp))
+        SocialButton(
+            label      = stringResource(Res.string.auth_continue_with_google),
+            background = Color.White,
+            textColor  = BasilPalette.AuthNearBlack,
+            borderColor = BasilPalette.AuthGoogleBorder,
+            onClick    = onGoogleSignIn,
         )
-        Spacer(Modifier.height(22.dp))
+        Spacer(Modifier.height(16.dp))
+        OrDivider()
+        Spacer(Modifier.height(12.dp))
         AuthFieldLabel(stringResource(Res.string.auth_field_email))
         Spacer(Modifier.height(6.dp))
         OutlinedTextField(
             value           = state.email,
             onValueChange   = onEmailChange,
             singleLine      = true,
-            placeholder     = { Text(stringResource(Res.string.auth_email_placeholder)) },
             keyboardOptions = KeyboardOptions(
                 keyboardType = KeyboardType.Email,
-                imeAction    = ImeAction.Next
+                imeAction    = ImeAction.Done,
             ),
-            colors   = authFieldColors(),
-            modifier = Modifier.fillMaxWidth()
+            keyboardActions = KeyboardActions(onDone = { onContinueEmail() }),
+            colors          = authFieldColors(),
+            shape           = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+            modifier        = Modifier
+                .fillMaxWidth()
+                .height(BasilTokens.AuthFieldHeight),
         )
+        Spacer(Modifier.height(8.dp))
+        PrimaryButton(
+            label   = stringResource(Res.string.auth_continue),
+            enabled = state.canContinueEmail,
+            onClick = onContinueEmail,
+        )
+    }
+}
+
+@Composable
+private fun SignInForm(
+    state:                      AuthUiState,
+    onPasswordChange:           (String) -> Unit,
+    onTogglePasswordVisibility: () -> Unit,
+    onUseDifferentAccount:      () -> Unit,
+    onSubmit:                   () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(top = 24.dp, bottom = 28.dp),
+    ) {
+        Spacer(Modifier.height(16.dp))
+        Text(
+            text  = stringResource(Res.string.auth_welcome_back),
+            style = MaterialTheme.typography.headlineSmall,
+            color = BasilPalette.AuthNearBlack,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = stringResource(Res.string.auth_signin_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = BasilPalette.AuthFieldText,
+        )
+        Spacer(Modifier.height(22.dp))
+        AuthFieldLabel(stringResource(Res.string.auth_field_email))
+        Spacer(Modifier.height(6.dp))
+        LockedField(text = state.email)
         Spacer(Modifier.height(14.dp))
         AuthFieldLabel(stringResource(Res.string.auth_field_password))
         Spacer(Modifier.height(6.dp))
@@ -201,95 +318,242 @@ private fun AuthForm(
             value                = state.password,
             onValueChange        = onPasswordChange,
             singleLine           = true,
-            placeholder          = { Text("••••••••") },
-            visualTransformation = PasswordVisualTransformation(),
+            visualTransformation = if (state.isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
             keyboardOptions      = KeyboardOptions(
                 keyboardType = KeyboardType.Password,
-                imeAction    = ImeAction.Done
+                imeAction    = ImeAction.Done,
             ),
             keyboardActions = KeyboardActions(onDone = { onSubmit() }),
+            trailingIcon = {
+                IconButton(onClick = onTogglePasswordVisibility) {
+                    Icon(
+                        imageVector        = if (state.isPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                        contentDescription = stringResource(
+                            if (state.isPasswordVisible) Res.string.cd_hide_password else Res.string.cd_show_password
+                        ),
+                        tint = BasilPalette.AuthFieldText,
+                    )
+                }
+            },
             colors   = authFieldColors(),
-            modifier = Modifier.fillMaxWidth()
+            shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+            modifier = Modifier
+                .fillMaxWidth()
+                .height(BasilTokens.AuthFieldHeight),
         )
         state.error?.let { errorRes ->
             Spacer(Modifier.height(8.dp))
             Text(
                 text  = stringResource(errorRes),
                 style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.error
+                color = MaterialTheme.colorScheme.error,
             )
         }
-        Spacer(Modifier.height(22.dp))
-        AuthSubmitArea(state = state, onToggle = onToggle, onSubmit = onSubmit)
+        Spacer(Modifier.height(6.dp))
+        Text(
+            text     = stringResource(Res.string.auth_forgot_password),
+            style    = MaterialTheme.typography.labelMedium,
+            color    = BasilPalette.Sage600,
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 14.dp),
+            textAlign = TextAlign.End,
+        )
+        if (state.isLoading) {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = BasilPalette.Sage600)
+            }
+        } else {
+            PrimaryButton(
+                label   = stringResource(Res.string.auth_sign_in),
+                enabled = state.canSubmit,
+                onClick = onSubmit,
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+        CenteredLink(
+            text    = stringResource(Res.string.auth_use_different_account),
+            onClick = onUseDifferentAccount,
+        )
     }
 }
+
+@Composable
+private fun NoAccountFound(
+    email:                 String,
+    onUseDifferentAccount: () -> Unit,
+    onGetStarted:          () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(top = 24.dp, bottom = 28.dp),
+    ) {
+        Spacer(Modifier.height(16.dp))
+        LockedField(text = email, trailingIcon = Icons.Default.Close)
+        Spacer(Modifier.height(14.dp))
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(BasilTokens.AuthInfoCardCorner))
+                .background(BasilPalette.AuthInfoCardBg)
+                .padding(horizontal = 16.dp, vertical = 14.dp),
+        ) {
+            Text(
+                text       = stringResource(Res.string.auth_no_account_title),
+                style      = MaterialTheme.typography.labelLarge,
+                color      = BasilPalette.Sage600,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Spacer(Modifier.height(3.dp))
+            Text(
+                text  = stringResource(Res.string.auth_no_account_body),
+                style = MaterialTheme.typography.bodySmall,
+                color = BasilPalette.Sage600.copy(alpha = 0.8f),
+            )
+        }
+        Spacer(Modifier.height(16.dp))
+        PrimaryButton(
+            label   = stringResource(Res.string.auth_get_started),
+            enabled = true,
+            onClick = onGetStarted,
+        )
+        Spacer(Modifier.height(12.dp))
+        CenteredLink(
+            text    = stringResource(Res.string.auth_try_different_email),
+            onClick = onUseDifferentAccount,
+        )
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Shared pieces
+// ─────────────────────────────────────────────────────────────
 
 @Composable
 private fun AuthFieldLabel(text: String) {
     Text(
         text          = text.uppercase(),
         style         = MaterialTheme.typography.labelSmall,
-        color         = BasilPalette.Stone500,
+        color         = BasilPalette.AuthFieldText,
         fontWeight    = FontWeight.SemiBold,
-        letterSpacing = 0.8.sp
+        letterSpacing = 0.3.sp,
     )
 }
 
 @Composable
-private fun AuthSubmitArea(
-    state:    AuthFormState,
-    onToggle: () -> Unit,
-    onSubmit: () -> Unit
-) {
-    Column(
-        modifier            = Modifier.fillMaxWidth(),
-        horizontalAlignment = Alignment.CenterHorizontally
+private fun LockedField(text: String, trailingIcon: ImageVector? = null) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BasilTokens.AuthFieldHeight)
+            .clip(RoundedCornerShape(BasilTokens.AuthFieldCorner))
+            .background(BasilPalette.Cream)
+            .padding(horizontal = 16.dp),
+        verticalAlignment = Alignment.CenterVertically,
     ) {
-        if (state.isLoading) {
-            CircularProgressIndicator(color = BasilPalette.Sage600)
-        } else {
-            val buttonLabel = if (state.isSignUp) {
-                stringResource(Res.string.auth_create_account)
-            } else {
-                stringResource(Res.string.auth_sign_in)
-            }
-            Button(
-                onClick  = onSubmit,
-                enabled  = state.canSubmit,
-                shape    = RoundedCornerShape(50),
-                colors   = ButtonDefaults.buttonColors(
-                    containerColor = BasilPalette.Sage600,
-                    contentColor   = Color.White
-                ),
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .height(BasilTokens.ButtonHeight)
-            ) {
-                Text(text = buttonLabel, style = MaterialTheme.typography.labelLarge)
-            }
-        }
-        Spacer(Modifier.height(14.dp))
-        val toggleLabel = if (state.isSignUp) {
-            stringResource(Res.string.auth_toggle_to_signin)
-        } else {
-            stringResource(Res.string.auth_toggle_to_signup)
-        }
-        TextButton(onClick = onToggle) {
-            Text(
-                text  = toggleLabel,
-                style = MaterialTheme.typography.bodyMedium,
-                color = BasilPalette.Sage600
-            )
+        Text(
+            text     = text,
+            style    = MaterialTheme.typography.bodyLarge,
+            color    = BasilPalette.AuthFieldText,
+            modifier = Modifier.weight(1f),
+        )
+        trailingIcon?.let {
+            Icon(imageVector = it, contentDescription = null, tint = BasilPalette.AuthPlaceholderText)
         }
     }
 }
 
 @Composable
+private fun PrimaryButton(label: String, enabled: Boolean, onClick: () -> Unit) {
+    Button(
+        onClick  = onClick,
+        enabled  = enabled,
+        shape    = RoundedCornerShape(50),
+        colors   = ButtonDefaults.buttonColors(
+            containerColor         = BasilPalette.Sage600,
+            contentColor            = Color.White,
+            disabledContainerColor  = BasilPalette.AuthButtonMuted,
+            disabledContentColor    = Color.White,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BasilTokens.ButtonHeight),
+    ) {
+        Text(text = label, style = MaterialTheme.typography.labelLarge)
+    }
+}
+
+@Composable
+private fun SocialButton(
+    label:       String,
+    background:  Color,
+    textColor:   Color,
+    borderColor: Color? = null,
+    onClick:     () -> Unit,
+) {
+    val border = borderColor?.let {
+        BorderStroke(1.5.dp, it)
+    }
+    OutlinedButton(
+        onClick  = onClick,
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        border   = border ?: BorderStroke(0.dp, Color.Transparent),
+        colors   = ButtonDefaults.outlinedButtonColors(
+            containerColor = background,
+            contentColor   = textColor,
+        ),
+        modifier = Modifier
+            .fillMaxWidth()
+            .height(BasilTokens.ButtonHeight),
+    ) {
+        Text(text = label, style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Medium)
+    }
+}
+
+@Composable
+private fun OrDivider() {
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color    = BasilPalette.AuthFieldBorder.copy(alpha = 0.3f),
+        )
+        Text(
+            text     = stringResource(Res.string.auth_or),
+            style    = MaterialTheme.typography.bodyMedium,
+            color    = BasilPalette.AuthFieldText,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+        HorizontalDivider(
+            modifier = Modifier.weight(1f),
+            color    = BasilPalette.AuthFieldBorder.copy(alpha = 0.3f),
+        )
+    }
+}
+
+@Composable
+private fun CenteredLink(text: String, onClick: () -> Unit) {
+    TextButton(onClick = onClick, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text  = text,
+            style = MaterialTheme.typography.bodyMedium,
+            color = BasilPalette.Sage600,
+            fontWeight = FontWeight.Medium,
+        )
+    }
+}
+
+@Composable
 private fun authFieldColors() = OutlinedTextFieldDefaults.colors(
-    focusedBorderColor   = BasilPalette.Sage600,
-    unfocusedBorderColor = BasilPalette.Stone200,
-    focusedLabelColor    = BasilPalette.Sage600,
-    cursorColor          = BasilPalette.Sage600
+    focusedContainerColor   = BasilPalette.Cream,
+    unfocusedContainerColor = BasilPalette.Cream,
+    focusedBorderColor      = BasilPalette.Sage600,
+    unfocusedBorderColor    = BasilPalette.AuthFieldBorder,
+    focusedTextColor        = BasilPalette.AuthNearBlack,
+    unfocusedTextColor      = BasilPalette.AuthNearBlack,
+    cursorColor             = BasilPalette.Sage600,
 )
 
 // ─────────────────────────────────────────────────────────────
@@ -298,28 +562,65 @@ private fun authFieldColors() = OutlinedTextFieldDefaults.colors(
 
 @Preview
 @Composable
-internal fun AuthScreenSignInPreview() {
+internal fun AuthScreenEmailStepPreview() {
     BasilTheme {
         AuthScreenContent(
-            state            = AuthFormState(),
-            onEmailChange    = {},
-            onPasswordChange = {},
-            onToggle         = {},
-            onSubmit         = {}
+            state                      = AuthUiState(),
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onContinueEmail            = {},
+            onUseDifferentAccount      = {},
+            onSubmit                   = {},
+            onGoogleSignIn             = {},
+            onAppleSignIn              = {},
+            onGetStarted               = {},
         )
     }
 }
 
 @Preview
 @Composable
-internal fun AuthScreenSignUpPreview() {
+internal fun AuthScreenSignInPreview() {
     BasilTheme {
         AuthScreenContent(
-            state            = AuthFormState(isSignUp = true),
-            onEmailChange    = {},
-            onPasswordChange = {},
-            onToggle         = {},
-            onSubmit         = {}
+            state = AuthUiState(
+                email     = "john@example.com",
+                emailStep = false,
+                mode      = AuthMode.SignIn,
+            ),
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onContinueEmail            = {},
+            onUseDifferentAccount      = {},
+            onSubmit                   = {},
+            onGoogleSignIn             = {},
+            onAppleSignIn              = {},
+            onGetStarted               = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun AuthScreenNoAccountPreview() {
+    BasilTheme {
+        AuthScreenContent(
+            state = AuthUiState(
+                email     = "new@email.com",
+                emailStep = false,
+                mode      = AuthMode.SignUp,
+            ),
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onContinueEmail            = {},
+            onUseDifferentAccount      = {},
+            onSubmit                   = {},
+            onGoogleSignIn             = {},
+            onAppleSignIn              = {},
+            onGetStarted               = {},
         )
     }
 }
@@ -329,15 +630,22 @@ internal fun AuthScreenSignUpPreview() {
 internal fun AuthScreenLoadingPreview() {
     BasilTheme {
         AuthScreenContent(
-            state            = AuthFormState(
+            state = AuthUiState(
                 email     = "gavin@example.com",
-                password  = "••••••••",
-                isLoading = true
+                password  = "password123",
+                emailStep = false,
+                mode      = AuthMode.SignIn,
+                isLoading = true,
             ),
-            onEmailChange    = {},
-            onPasswordChange = {},
-            onToggle         = {},
-            onSubmit         = {}
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onContinueEmail            = {},
+            onUseDifferentAccount      = {},
+            onSubmit                   = {},
+            onGoogleSignIn             = {},
+            onAppleSignIn              = {},
+            onGetStarted               = {},
         )
     }
 }
@@ -347,15 +655,22 @@ internal fun AuthScreenLoadingPreview() {
 internal fun AuthScreenErrorPreview() {
     BasilTheme {
         AuthScreenContent(
-            state            = AuthFormState(
-                email  = "gavin@example.com",
-                password = "wrongpassword",
-                error  = Res.string.error_auth_failed
+            state = AuthUiState(
+                email     = "gavin@example.com",
+                password  = "wrongpassword",
+                emailStep = false,
+                mode      = AuthMode.SignIn,
+                error     = Res.string.error_auth_failed,
             ),
-            onEmailChange    = {},
-            onPasswordChange = {},
-            onToggle         = {},
-            onSubmit         = {}
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onContinueEmail            = {},
+            onUseDifferentAccount      = {},
+            onSubmit                   = {},
+            onGoogleSignIn             = {},
+            onAppleSignIn              = {},
+            onGetStarted               = {},
         )
     }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
@@ -12,69 +12,99 @@ import basil.composeapp.generated.resources.error_auth_failed
 import org.jetbrains.compose.resources.StringResource
 import org.weekendware.basil.data.repository.AuthRepository
 
+/** Whether the auth screen is presenting a returning user's sign-in, or a new user's path to onboarding. */
+enum class AuthMode { SignIn, SignUp }
+
 /**
- * Form state for the authentication screen.
+ * State for the email-first auth screen.
  *
- * @property email        Current value of the email field.
- * @property password     Current value of the password field.
- * @property isSignUp     When true the form submits as sign-up; false = sign-in.
- * @property isLoading    True while an auth network call is in flight.
- * @property error        User-facing error string resource, or null when there is none.
+ * @property mode              Whether the entered email matched a stored one (SignIn) or not (SignUp).
+ * @property email             Current value of the email field.
+ * @property password          Current value of the password field. Unused while [emailStep] is true.
+ * @property emailStep         True while the user is on the email-only step; false once past it.
+ * @property isLoading         True while an auth network call is in flight.
+ * @property isPasswordVisible True when the password field shows plain text instead of masked dots.
+ * @property error             User-facing error string resource, or null when there is none.
  */
 @Immutable
-data class AuthFormState(
+data class AuthUiState(
+    val mode: AuthMode = AuthMode.SignIn,
     val email: String = "",
     val password: String = "",
-    val isSignUp: Boolean = false,
+    val emailStep: Boolean = true,
     val isLoading: Boolean = false,
-    val error: StringResource? = null
+    val isPasswordVisible: Boolean = false,
+    val error: StringResource? = null,
 ) {
-    val canSubmit: Boolean get() = email.isNotBlank() && password.length >= 6 && !isLoading
+    val canContinueEmail: Boolean get() = email.isNotBlank() && !isLoading
+    val canSubmit: Boolean get() = password.isNotBlank() && !isLoading
 }
 
 /**
  * ViewModel for [AuthScreen].
  *
- * Delegates credential operations to [AuthRepository] and surfaces
- * results through [state]. Navigation after a successful auth is handled
- * reactively by [SessionViewModel] — no explicit success callback is needed.
+ * Email-first, detect-by-email flow: the user enters an email and taps
+ * Continue; if it matches [AuthRepository.lastUsedEmail] (the only
+ * detection signal available — Supabase's enumeration protection rules out
+ * a real server-side lookup) the screen advances to a password step,
+ * otherwise it shows the no-account-found state. Delegates credential
+ * operations to [AuthRepository] and surfaces results through [state].
+ * Navigation after a successful auth is handled reactively by
+ * [org.weekendware.basil.presentation.session.SessionViewModel] — no
+ * explicit success callback is needed.
  */
 class AuthViewModel(
     private val authRepository: AuthRepository
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(AuthFormState())
+    private val _state = MutableStateFlow(AuthUiState())
 
     /** The current form state observed by [AuthScreen]. */
-    val state: StateFlow<AuthFormState> = _state
+    val state: StateFlow<AuthUiState> = _state
 
     fun onEmailChange(value: String) = _state.update { it.copy(email = value, error = null) }
     fun onPasswordChange(value: String) = _state.update { it.copy(password = value, error = null) }
-    fun toggleMode() = _state.update { it.copy(isSignUp = !it.isSignUp, error = null) }
+    fun onTogglePasswordVisibility() = _state.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
 
-    /** Submits sign-in or sign-up depending on [AuthFormState.isSignUp]. */
+    /** Advances from the email step, choosing SignIn or SignUp mode via the detect-by-email heuristic. */
+    fun onContinueEmail() {
+        val current = _state.value
+        if (!current.canContinueEmail) return
+        val recognized = current.email == authRepository.lastUsedEmail()
+        _state.update {
+            it.copy(emailStep = false, mode = if (recognized) AuthMode.SignIn else AuthMode.SignUp)
+        }
+    }
+
+    /** Returns to a fresh email step, discarding the entered email and password. */
+    fun onUseDifferentAccount() = _state.update { AuthUiState() }
+
+    /** Submits sign-in with the current email/password. No-op outside [AuthMode.SignIn] — this screen never signs up directly. */
     fun submit() {
         val current = _state.value
-        if (!current.canSubmit) return
+        if (current.mode != AuthMode.SignIn || !current.canSubmit) return
 
         _state.update { it.copy(isLoading = true, error = null) }
 
         viewModelScope.launch {
-            val result = if (current.isSignUp) {
-                authRepository.signUp(current.email, current.password)
-            } else {
-                authRepository.signIn(current.email, current.password)
-            }
-
+            val result = authRepository.signIn(current.email, current.password)
             result.fold(
-                onSuccess = {
-                    // SessionViewModel will observe the auth state change and
-                    // navigate automatically — nothing to do here.
-                    _state.update { it.copy(isLoading = false) }
-                },
-                onFailure = {
-                    _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) }
-                }
+                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
+            )
+        }
+    }
+
+    fun onGoogleSignIn() = signInWithProvider(authRepository::signInWithGoogle)
+    fun onAppleSignIn() = signInWithProvider(authRepository::signInWithApple)
+
+    private fun signInWithProvider(provider: suspend () -> Result<Unit>) {
+        _state.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            val result = provider()
+            result.fold(
+                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
@@ -131,6 +131,16 @@ internal object BasilPalette {
     val OnError           = Color(0xFFFFFFFF)
     val ErrorContainer    = Color(0xFFFFDAD6)
     val OnErrorContainer  = Color(0xFF410002)
+
+    // Auth screens — literal, hand-picked by UI Designer, not derived from
+    // the seed palette. Same treatment as Cream above.
+    val AuthFieldBorder     = Color(0xFF858078)
+    val AuthFieldText       = Color(0xFF4E6A50)
+    val AuthButtonMuted     = Color(0xFFA8BAA5)
+    val AuthGoogleBorder    = Color(0xFFE8E4DF)
+    val AuthInfoCardBg      = Color(0xFFD4E8D6)
+    val AuthPlaceholderText = Color(0xFFB8B0A8)
+    val AuthNearBlack       = Color(0xFF1A1816)
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilTokens.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilTokens.kt
@@ -66,9 +66,15 @@ object BasilTokens {
     val SplashLeafSize = 48.dp
 
     // ── Auth screen ───────────────────────────────────────────
-    /** Corner radius of the hero band's bottom edge on the auth screen. */
-    val AuthHeroCorner = 32.dp
-    /** Size of the leaf mark inside the auth hero band. */
-    val AuthHeroLeafSize = 38.dp
+    /** Height of email/password fields on the auth screen — narrower than the standard [InputHeight]. */
+    val AuthFieldHeight = 52.dp
+    /** Corner radius of auth fields and the Apple/Google buttons. */
+    val AuthFieldCorner = 12.dp
+    /** Corner radius of the "no account found" info card. */
+    val AuthInfoCardCorner = 10.dp
+    /** Size of the logo placeholder in the auth hero band. */
+    val AuthLogoSize = 52.dp
+    /** Corner radius of the logo placeholder in the auth hero band. */
+    val AuthLogoCorner = 14.dp
 
 }

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
@@ -37,58 +37,114 @@ class AuthViewModelTest {
     }
 
     @Test
-    fun `initial state is empty sign-in form`() {
+    fun `initial state is the email step, sign-in mode, nothing entered`() {
         val state = viewModel.state.value
+        assertTrue(state.emailStep)
+        assertEquals(AuthMode.SignIn, state.mode)
         assertEquals("", state.email)
         assertEquals("", state.password)
-        assertFalse(state.isSignUp)
         assertFalse(state.isLoading)
+        assertFalse(state.isPasswordVisible)
         assertNull(state.error)
     }
 
     @Test
-    fun `canSubmit is false when email is blank`() {
+    fun `canContinueEmail is false when email is blank`() {
+        assertFalse(viewModel.state.value.canContinueEmail)
+    }
+
+    @Test
+    fun `canContinueEmail is true once an email is entered`() {
+        viewModel.onEmailChange("user@test.com")
+        assertTrue(viewModel.state.value.canContinueEmail)
+    }
+
+    @Test
+    fun `onContinueEmail does nothing when the email is blank`() {
+        viewModel.onContinueEmail()
+        assertTrue(viewModel.state.value.emailStep)
+    }
+
+    @Test
+    fun `onContinueEmail with an unrecognized email advances to SignUp mode`() {
+        viewModel.onEmailChange("new@test.com")
+        viewModel.onContinueEmail()
+        val state = viewModel.state.value
+        assertFalse(state.emailStep)
+        assertEquals(AuthMode.SignUp, state.mode)
+    }
+
+    @Test
+    fun `onContinueEmail with a recognized email advances to SignIn mode`() = runTest {
+        repo.signIn("returning@test.com", "password123")
+        viewModel.onEmailChange("returning@test.com")
+        viewModel.onContinueEmail()
+        val state = viewModel.state.value
+        assertFalse(state.emailStep)
+        assertEquals(AuthMode.SignIn, state.mode)
+    }
+
+    @Test
+    fun `onUseDifferentAccount resets to a fresh email step`() {
+        viewModel.onEmailChange("user@test.com")
         viewModel.onPasswordChange("password123")
+        viewModel.onContinueEmail()
+
+        viewModel.onUseDifferentAccount()
+
+        val state = viewModel.state.value
+        assertTrue(state.emailStep)
+        assertEquals("", state.email)
+        assertEquals("", state.password)
+    }
+
+    @Test
+    fun `onTogglePasswordVisibility flips the flag`() {
+        assertFalse(viewModel.state.value.isPasswordVisible)
+        viewModel.onTogglePasswordVisibility()
+        assertTrue(viewModel.state.value.isPasswordVisible)
+        viewModel.onTogglePasswordVisibility()
+        assertFalse(viewModel.state.value.isPasswordVisible)
+    }
+
+    @Test
+    fun `canSubmit is false when password is blank`() {
         assertFalse(viewModel.state.value.canSubmit)
     }
 
     @Test
-    fun `canSubmit is false when password is shorter than 6 characters`() {
-        viewModel.onEmailChange("user@test.com")
-        viewModel.onPasswordChange("abc")
-        assertFalse(viewModel.state.value.canSubmit)
-    }
-
-    @Test
-    fun `canSubmit is true when email and password meet requirements`() {
-        viewModel.onEmailChange("user@test.com")
+    fun `canSubmit is true once a password is entered`() {
         viewModel.onPasswordChange("password123")
         assertTrue(viewModel.state.value.canSubmit)
     }
 
-    @Test
-    fun `toggleMode switches between sign-in and sign-up`() {
-        assertFalse(viewModel.state.value.isSignUp)
-        viewModel.toggleMode()
-        assertTrue(viewModel.state.value.isSignUp)
-        viewModel.toggleMode()
-        assertFalse(viewModel.state.value.isSignUp)
+    /** Primes the fake so [email] is "recognized" by the detect-by-email heuristic, then signs back out. */
+    private suspend fun primeRecognizedEmail(email: String) {
+        repo.signIn(email, "priming-password")
+        repo.signOut()
     }
 
     @Test
     fun `successful sign-in clears loading and error`() = runTest {
+        primeRecognizedEmail("user@test.com")
         viewModel.onEmailChange("user@test.com")
+        viewModel.onContinueEmail()
+        assertEquals(AuthMode.SignIn, viewModel.state.value.mode)
         viewModel.onPasswordChange("password123")
         viewModel.submit()
         val state = viewModel.state.value
         assertFalse(state.isLoading)
         assertNull(state.error)
+        assertTrue(repo.isSignedIn())
     }
 
     @Test
     fun `failed sign-in surfaces error message`() = runTest {
+        primeRecognizedEmail("user@test.com")
         repo.signInResult = Result.failure(Exception("Invalid credentials"))
         viewModel.onEmailChange("user@test.com")
+        viewModel.onContinueEmail()
+        assertEquals(AuthMode.SignIn, viewModel.state.value.mode)
         viewModel.onPasswordChange("password123")
         viewModel.submit()
         assertEquals(Res.string.error_auth_failed, viewModel.state.value.error)
@@ -96,12 +152,44 @@ class AuthViewModelTest {
     }
 
     @Test
+    fun `submit is a no-op in SignUp mode`() = runTest {
+        viewModel.onEmailChange("new@test.com")
+        viewModel.onContinueEmail() // unrecognized email -> SignUp mode
+        assertEquals(AuthMode.SignUp, viewModel.state.value.mode)
+
+        viewModel.submit()
+
+        assertFalse(repo.isSignedIn())
+    }
+
+    @Test
     fun `onEmailChange clears existing error`() = runTest {
+        primeRecognizedEmail("user@test.com")
         repo.signInResult = Result.failure(Exception("error"))
         viewModel.onEmailChange("user@test.com")
+        viewModel.onContinueEmail()
         viewModel.onPasswordChange("password123")
         viewModel.submit()
+        assertEquals(Res.string.error_auth_failed, viewModel.state.value.error) // sanity: error was actually set
         viewModel.onEmailChange("new@test.com")
         assertNull(viewModel.state.value.error)
+    }
+
+    @Test
+    fun `successful Google sign-in clears loading and error`() = runTest {
+        viewModel.onGoogleSignIn()
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `failed Apple sign-in surfaces error message`() = runTest {
+        repo.appleSignInResult = Result.failure(Exception("cancelled"))
+        viewModel.onAppleSignIn()
+        val state = viewModel.state.value
+        assertEquals(Res.string.error_auth_failed, state.error)
+        assertFalse(state.isLoading)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }


### PR DESCRIPTION
## Summary
Builds on #55 (needs \`AuthRepository.lastUsedEmail()\`), plus #56 and #58 merged in for testability. This is the "core flow first" scope from Gavin's sequencing call — the email-first sign-in/sign-up flow every returning user hits, matching mockup screens AUTH-01 (email step), AUTH-02 (account found → password), AUTH-03 (no account found). Passkeys, password reset, verification banner/wall, and save-progress are deliberately deferred to later sessions.

## Process note — this one breaks the pattern
Every other branch this session split cleanly into "QA writes failing tests + signature stubs" then "Builder implements." This one couldn't: \`AuthViewModel\`/\`AuthScreen\` already existed and already compiled. Changing the state shape (\`AuthFormState\` → \`AuthUiState\`) breaks \`AuthScreen.kt\` the moment it lands, so there's no way to commit a red-test-only intermediate state without leaving the module non-compiling. Test suite and full implementation landed together. Flagging this explicitly rather than pretending it fits the same shape as the rest of the series.

## What changed
- \`AuthUiState\` replaces \`AuthFormState\`: adds \`mode\` (SignIn/SignUp), \`emailStep\`, \`isPasswordVisible\`; drops \`isSignUp\`/\`toggleMode\` (meaningless once email is the first step)
- Detect-by-email heuristic: \`AuthRepository.lastUsedEmail()\` match decides SignIn vs SignUp client-side — matches the TDD's resolved decision (Supabase's enumeration protection rules out a real server lookup)
- \`AuthScreen\` rewritten to match the mockup: full hero band + tagline on the email step, compact hero after; Apple/Google social buttons (iOS Apple-first); locked email + password-with-visibility-toggle on sign-in; info card + "Get started" on no-account-found
- New \`BasilPalette\` auth colors and \`BasilTokens\` sized to the mockup exactly (52dp field height, not the existing 56dp \`InputHeight\` — mockups are exact source of truth, no approximating with an existing-but-wrong token)
- Removed \`AuthHeroCorner\`/\`AuthHeroLeafSize\`, now dead — the new hero band doesn't round corners or use the \`BasilLeaf\` vector (mockup uses a lettered placeholder square instead, pending the real logo mark)
- "Get started" takes a currently-no-op \`onGetStarted\` callback — the real onboarding-redirect navigation depends on the silent-account-provisioning \`App.kt\` routing deferred in an earlier branch (#57)

## Bug caught during testing
Three of my own test cases silently passed for the wrong reason: an unrecognized test email routed to \`SignUp\` mode, \`submit()\` correctly no-op'd there, and \`isLoading\`/\`error\` stayed at their harmless defaults — which happened to satisfy assertions that were supposed to be checking a real sign-in attempt. Caught when a fourth, differently-shaped test actually failed. Fixed all four by priming the fake with a recognized email first.

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\` — clean
- [x] \`:composeApp:compileDevDebugKotlinAndroid\`, \`:composeApp:compileKotlinDesktop\` — clean
- [x] Full suite green — 16 \`AuthViewModelTest\` cases, no regressions elsewhere
- [ ] Manual: verify against the mockup visually on a device/simulator (not verifiable from this environment)
- [ ] Copywriter pass on new strings (\`auth_no_account_body\` etc. are functional placeholder copy, not final voice)