### PR TITLE
Add password reset flow: request/sent and new-password screens

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -25,6 +25,20 @@
     <string name="auth_try_different_email">Try a different email</string>
     <string name="cd_show_password">Show password</string>
     <string name="cd_hide_password">Hide password</string>
+    <string name="cd_back">Back</string>
+
+    <!-- ── Password reset ────────────────────────────────────── -->
+    <string name="auth_reset_title">Reset your password</string>
+    <string name="auth_reset_subtitle">We\'ll send a reset link to your email address.</string>
+    <string name="auth_send_reset_link">Send reset link</string>
+    <string name="auth_check_email_title">Check your email</string>
+    <string name="auth_check_email_body">We sent a reset link to</string>
+    <string name="auth_resend_email">Resend email</string>
+    <string name="auth_new_password_title">Set a new password</string>
+    <string name="auth_new_password_subtitle">Choose something you\'ll remember.</string>
+    <string name="auth_field_new_password">New password</string>
+    <string name="auth_field_confirm_password">Confirm password</string>
+    <string name="auth_set_new_password">Set new password</string>
 
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -56,7 +56,7 @@ import basil.composeapp.generated.resources.nav_more
 import basil.composeapp.generated.resources.nav_profile
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
-import org.weekendware.basil.presentation.auth.AuthScreen
+import org.weekendware.basil.presentation.auth.AuthFlowScreen
 import org.weekendware.basil.presentation.chat.ChatScreen
 import org.weekendware.basil.presentation.more.MoreScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingScreen
@@ -105,7 +105,7 @@ fun App() {
                     SplashScreen(onFadeComplete = { splashDone = true })
                 } else {
                     when (sessionState) {
-                        SessionState.Unauthenticated -> AuthScreen()
+                        SessionState.Unauthenticated -> AuthFlowScreen()
                         SessionState.Authenticated   -> AuthenticatedRoot(themeHour = themeHour)
                         SessionState.Loading         -> Box(Modifier.fillMaxSize())
                     }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/AuthRepository.kt
@@ -48,6 +48,9 @@ interface AuthRepository {
     /** Sends a password reset email with a deep link back to the app. */
     suspend fun resetPassword(email: String): Result<Unit>
 
+    /** Sets [newPassword] on the session established by following a password-reset deep link. */
+    suspend fun updatePassword(newPassword: String): Result<Unit>
+
     /** Resends the verification email to the current user. */
     suspend fun resendVerificationEmail(): Result<Unit>
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -70,6 +70,9 @@ class SupabaseAuthRepository(
     override suspend fun resetPassword(email: String): Result<Unit> =
         TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Supabase deep links (password reset)")
 
+    override suspend fun updatePassword(newPassword: String): Result<Unit> =
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, Supabase deep links (password reset)")
+
     override suspend fun resendVerificationEmail(): Result<Unit> =
         TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC12")
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthFlowScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthFlowScreen.kt
@@ -1,0 +1,42 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/** Which screen [AuthFlowScreen] currently shows. */
+private sealed interface AuthDestination {
+    data object SignIn : AuthDestination
+    data class ResetRequest(val email: String) : AuthDestination
+}
+
+/**
+ * Owns local navigation between the sign-in screen and the password-reset
+ * request flow — the same "plain composable state, no nav library" pattern
+ * [org.weekendware.basil.AuthenticatedRoot] uses for tab switching. This is
+ * the entry point [org.weekendware.basil.App] should call instead of
+ * [AuthScreen] directly.
+ *
+ * [NewPasswordScreen] (AUTH-07) is deliberately not part of this flow — it's
+ * reached via a deep link, not in-app navigation, and that wiring doesn't
+ * exist yet.
+ *
+ * @param onGetStarted Forwarded to [AuthScreen] — see its documentation.
+ */
+@Composable
+fun AuthFlowScreen(onGetStarted: () -> Unit = {}) {
+    var destination by remember { mutableStateOf<AuthDestination>(AuthDestination.SignIn) }
+
+    when (val dest = destination) {
+        AuthDestination.SignIn -> AuthScreen(
+            onGetStarted     = onGetStarted,
+            onForgotPassword = { email -> destination = AuthDestination.ResetRequest(email) },
+        )
+        is AuthDestination.ResetRequest -> ResetPasswordScreen(
+            initialEmail = dest.email,
+            onBack       = { destination = AuthDestination.SignIn },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthScreen.kt
@@ -89,9 +89,11 @@ import org.weekendware.basil.presentation.theme.BasilTokens
  *   "Get started" on the no-account-found state. Currently a no-op by
  *   default — the full silent-account-provisioning redirect into
  *   onboarding is separate, not-yet-wired routing work.
+ * @param onForgotPassword Called with the current email when the user taps
+ *   "Forgot password?" on the sign-in step.
  */
 @Composable
-fun AuthScreen(onGetStarted: () -> Unit = {}) {
+fun AuthScreen(onGetStarted: () -> Unit = {}, onForgotPassword: (String) -> Unit = {}) {
     val viewModel = koinViewModel<AuthViewModel>()
     val state by viewModel.state.collectAsStateWithLifecycle()
     AuthScreenContent(
@@ -105,6 +107,7 @@ fun AuthScreen(onGetStarted: () -> Unit = {}) {
         onGoogleSignIn              = viewModel::onGoogleSignIn,
         onAppleSignIn               = viewModel::onAppleSignIn,
         onGetStarted                = onGetStarted,
+        onForgotPassword            = onForgotPassword,
     )
 }
 
@@ -125,6 +128,7 @@ fun AuthScreenContent(
     onGoogleSignIn:                () -> Unit,
     onAppleSignIn:                 () -> Unit,
     onGetStarted:                  () -> Unit,
+    onForgotPassword:               (String) -> Unit = {},
 ) {
     Column(
         modifier = Modifier
@@ -147,6 +151,7 @@ fun AuthScreenContent(
                 onTogglePasswordVisibility = onTogglePasswordVisibility,
                 onUseDifferentAccount      = onUseDifferentAccount,
                 onSubmit                   = onSubmit,
+                onForgotPassword           = { onForgotPassword(state.email) },
             )
             AuthMode.SignUp -> NoAccountFound(
                 email                 = state.email,
@@ -277,6 +282,7 @@ private fun SignInForm(
     onTogglePasswordVisibility: () -> Unit,
     onUseDifferentAccount:      () -> Unit,
     onSubmit:                   () -> Unit,
+    onForgotPassword:           () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -340,15 +346,18 @@ private fun SignInForm(
             )
         }
         Spacer(Modifier.height(6.dp))
-        Text(
-            text     = stringResource(Res.string.auth_forgot_password),
-            style    = MaterialTheme.typography.labelMedium,
-            color    = BasilPalette.Sage600,
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(bottom = 14.dp),
-            textAlign = TextAlign.End,
-        )
+        TextButton(
+            onClick  = onForgotPassword,
+            modifier = Modifier.fillMaxWidth().padding(bottom = 6.dp),
+        ) {
+            Text(
+                text      = stringResource(Res.string.auth_forgot_password),
+                style     = MaterialTheme.typography.labelMedium,
+                color     = BasilPalette.Sage600,
+                modifier  = Modifier.fillMaxWidth(),
+                textAlign = TextAlign.End,
+            )
+        }
         if (state.isLoading) {
             Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
                 CircularProgressIndicator(color = BasilPalette.Sage600)

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/NewPasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/NewPasswordScreen.kt
@@ -1,0 +1,308 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.app_name
+import basil.composeapp.generated.resources.auth_field_confirm_password
+import basil.composeapp.generated.resources.auth_field_new_password
+import basil.composeapp.generated.resources.auth_new_password_subtitle
+import basil.composeapp.generated.resources.auth_new_password_title
+import basil.composeapp.generated.resources.auth_set_new_password
+import basil.composeapp.generated.resources.cd_hide_password
+import basil.composeapp.generated.resources.cd_show_password
+import basil.composeapp.generated.resources.error_auth_failed
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
+import org.weekendware.basil.presentation.theme.BasilTokens
+
+/**
+ * New-password screen (AUTH-07) — reached via a password-reset deep link,
+ * not from in-app navigation, so there is no back affordance.
+ *
+ * Not wired into app routing yet: reaching this screen depends on
+ * [org.weekendware.basil.data.repository.DeepLinkHandler] actually
+ * triggering navigation on a successful deep-link exchange, which is a
+ * separate, not-yet-built event bridge from the data layer to the UI
+ * layer. This composable is complete and tested standalone, ready for
+ * that wiring once it exists.
+ */
+@Composable
+fun NewPasswordScreen() {
+    val viewModel = koinViewModel<NewPasswordViewModel>()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    NewPasswordScreenContent(
+        state                      = state,
+        onPasswordChange           = viewModel::onPasswordChange,
+        onConfirmPasswordChange    = viewModel::onConfirmPasswordChange,
+        onTogglePasswordVisibility = viewModel::onTogglePasswordVisibility,
+        onSubmit                   = viewModel::submit,
+    )
+}
+
+@Composable
+fun NewPasswordScreenContent(
+    state:                      NewPasswordUiState,
+    onPasswordChange:           (String) -> Unit,
+    onConfirmPasswordChange:    (String) -> Unit,
+    onTogglePasswordVisibility: () -> Unit,
+    onSubmit:                   () -> Unit,
+) {
+    Column(modifier = Modifier.fillMaxSize().background(BasilPalette.Cream)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BasilPalette.Sage600)
+                .statusBarsPadding()
+                .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 24.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(BasilTokens.AuthLogoSize)
+                    .clip(RoundedCornerShape(BasilTokens.AuthLogoCorner))
+                    .background(Color.White.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(text = "b", style = MaterialTheme.typography.headlineMedium, color = Color.White)
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(text = stringResource(Res.string.app_name), style = MaterialTheme.typography.displaySmall, color = Color.White)
+        }
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(horizontal = 20.dp)
+                .padding(top = 20.dp, bottom = 28.dp),
+        ) {
+            Text(
+                text  = stringResource(Res.string.auth_new_password_title),
+                style = MaterialTheme.typography.headlineSmall,
+                color = BasilPalette.AuthNearBlack,
+            )
+            Spacer(Modifier.height(4.dp))
+            Text(
+                text  = stringResource(Res.string.auth_new_password_subtitle),
+                style = MaterialTheme.typography.bodyMedium,
+                color = BasilPalette.AuthFieldText,
+            )
+            Spacer(Modifier.height(22.dp))
+            PasswordFieldLabel(stringResource(Res.string.auth_field_new_password))
+            Spacer(Modifier.height(6.dp))
+            PasswordField(
+                value                = state.password,
+                onValueChange        = onPasswordChange,
+                isVisible            = state.isPasswordVisible,
+                onToggleVisibility   = onTogglePasswordVisibility,
+                borderColorOverride  = if (state.passwordStrength == PasswordStrength.Strong) BasilPalette.AuthStrengthGreen else null,
+            )
+            StrengthIndicator(strength = state.passwordStrength, requirements = state.passwordRequirements)
+            Spacer(Modifier.height(14.dp))
+            PasswordFieldLabel(stringResource(Res.string.auth_field_confirm_password))
+            Spacer(Modifier.height(6.dp))
+            PasswordField(
+                value              = state.confirmPassword,
+                onValueChange      = onConfirmPasswordChange,
+                isVisible          = state.isPasswordVisible,
+                onToggleVisibility = onTogglePasswordVisibility,
+            )
+            state.error?.let { errorRes ->
+                Spacer(Modifier.height(8.dp))
+                Text(text = stringResource(errorRes), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+            }
+            Spacer(Modifier.height(8.dp))
+            if (state.isLoading) {
+                Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                    CircularProgressIndicator(color = BasilPalette.Sage600)
+                }
+            } else {
+                Button(
+                    onClick  = onSubmit,
+                    enabled  = state.canSubmit,
+                    shape    = RoundedCornerShape(50),
+                    colors   = ButtonDefaults.buttonColors(
+                        containerColor         = BasilPalette.Sage600,
+                        contentColor            = Color.White,
+                        disabledContainerColor  = BasilPalette.AuthButtonMuted,
+                        disabledContentColor    = Color.White,
+                    ),
+                    modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+                ) {
+                    Text(text = stringResource(Res.string.auth_set_new_password), style = MaterialTheme.typography.labelLarge)
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun PasswordFieldLabel(text: String) {
+    Text(
+        text          = text.uppercase(),
+        style         = MaterialTheme.typography.labelSmall,
+        color         = BasilPalette.AuthFieldText,
+        fontWeight    = FontWeight.SemiBold,
+    )
+}
+
+@Composable
+private fun PasswordField(
+    value:               String,
+    onValueChange:       (String) -> Unit,
+    isVisible:           Boolean,
+    onToggleVisibility:  () -> Unit,
+    borderColorOverride: Color? = null,
+) {
+    OutlinedTextField(
+        value                = value,
+        onValueChange        = onValueChange,
+        singleLine           = true,
+        visualTransformation = if (isVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        keyboardOptions      = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+        keyboardActions      = KeyboardActions(),
+        trailingIcon = {
+            IconButton(onClick = onToggleVisibility) {
+                Icon(
+                    imageVector        = if (isVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                    contentDescription = stringResource(if (isVisible) Res.string.cd_hide_password else Res.string.cd_show_password),
+                    tint               = BasilPalette.AuthFieldText,
+                )
+            }
+        },
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedContainerColor   = BasilPalette.Cream,
+            unfocusedContainerColor = BasilPalette.Cream,
+            focusedBorderColor      = borderColorOverride ?: BasilPalette.Sage600,
+            unfocusedBorderColor    = borderColorOverride ?: BasilPalette.AuthFieldBorder,
+            cursorColor             = BasilPalette.Sage600,
+        ),
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.AuthFieldHeight),
+    )
+}
+
+@Composable
+private fun StrengthIndicator(strength: PasswordStrength, requirements: List<PasswordRequirement>) {
+    if (strength == PasswordStrength.None) return
+
+    val (filledCount, color, label) = when (strength) {
+        PasswordStrength.Weak   -> Triple(1, BasilPalette.Error, "Weak")
+        PasswordStrength.Medium -> Triple(2, BasilPalette.AuthStrengthAmber, "Medium")
+        PasswordStrength.Strong -> Triple(3, BasilPalette.AuthStrengthGreen, "Strong")
+        PasswordStrength.None   -> Triple(0, BasilPalette.AuthFieldBorder, "")
+    }
+
+    Column(modifier = Modifier.padding(top = 10.dp, bottom = 10.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            repeat(3) { index ->
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(4.dp)
+                        .padding(end = if (index < 2) 3.dp else 0.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(if (index < filledCount) color else BasilPalette.AuthGoogleBorder),
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(text = label, style = MaterialTheme.typography.labelSmall, color = color, fontWeight = FontWeight.SemiBold)
+        }
+        Spacer(Modifier.height(8.dp))
+        Column {
+            requirements.forEach { requirement ->
+                Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 2.dp)) {
+                    Box(
+                        modifier = if (requirement.met) {
+                            Modifier
+                                .size(14.dp)
+                                .clip(CircleShape)
+                                .background(BasilPalette.Sage600)
+                        } else {
+                            Modifier
+                                .size(14.dp)
+                                .clip(CircleShape)
+                                .border(1.5.dp, BasilPalette.AuthFieldBorder, CircleShape)
+                        },
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        if (requirement.met) {
+                            Text(text = "✓", style = MaterialTheme.typography.labelSmall, color = Color.White)
+                        }
+                    }
+                    Spacer(Modifier.width(7.dp))
+                    Text(
+                        text  = stringResource(requirement.label),
+                        style = MaterialTheme.typography.labelSmall,
+                        color = BasilPalette.AuthFieldText,
+                    )
+                }
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun NewPasswordEmptyPreview() {
+    BasilTheme {
+        NewPasswordScreenContent(
+            state                      = NewPasswordUiState(),
+            onPasswordChange           = {},
+            onConfirmPasswordChange    = {},
+            onTogglePasswordVisibility = {},
+            onSubmit                   = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/NewPasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/NewPasswordViewModel.kt
@@ -1,0 +1,72 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.data.repository.AuthRepository
+
+/**
+ * State for the new-password screen (AUTH-07), reached via a password-reset
+ * deep link.
+ *
+ * @property isPasswordVisible Shared by both fields — per the TDD, when a
+ *   screen has both a new-password and confirm-password field, they mask
+ *   or reveal together rather than toggling independently.
+ */
+@Immutable
+data class NewPasswordUiState(
+    val password: String = "",
+    val confirmPassword: String = "",
+    val isPasswordVisible: Boolean = false,
+    val passwordStrength: PasswordStrength = PasswordStrength.None,
+    val passwordRequirements: List<PasswordRequirement> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: StringResource? = null,
+) {
+    val passwordsMatch: Boolean get() = confirmPassword.isNotEmpty() && password == confirmPassword
+    val canSubmit: Boolean get() = passwordStrength == PasswordStrength.Strong && passwordsMatch && !isLoading
+}
+
+/**
+ * ViewModel for AUTH-07. The sign-up CTA stays disabled until the password
+ * is [PasswordStrength.Strong] and the confirm field matches it exactly.
+ */
+class NewPasswordViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(NewPasswordUiState())
+    val state: StateFlow<NewPasswordUiState> = _state
+
+    fun onPasswordChange(value: String) {
+        val (strength, requirements) = PasswordStrengthValidator.validate(value)
+        _state.update {
+            it.copy(password = value, passwordStrength = strength, passwordRequirements = requirements, error = null)
+        }
+    }
+
+    fun onConfirmPasswordChange(value: String) = _state.update { it.copy(confirmPassword = value, error = null) }
+    fun onTogglePasswordVisibility() = _state.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
+
+    fun submit() {
+        val current = _state.value
+        if (!current.canSubmit) return
+
+        _state.update { it.copy(isLoading = true, error = null) }
+
+        viewModelScope.launch {
+            val result = authRepository.updatePassword(current.password)
+            result.fold(
+                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
@@ -1,0 +1,59 @@
+package org.weekendware.basil.presentation.auth
+
+import org.jetbrains.compose.resources.StringResource
+
+/**
+ * Strength classification for a candidate password, driving the 3-segment
+ * strength bar on sign-up and the reset flow's new-password step.
+ *
+ * See `spec-splash-auth-07222026.md` AC18 and
+ * `tdd-splash-auth-07222026.md` "Data structures and algorithms".
+ */
+sealed class PasswordStrength {
+    /** No input yet — strength bar is hidden. */
+    data object None : PasswordStrength()
+
+    /** 0–2 of 5 requirements met — 1 red segment. */
+    data object Weak : PasswordStrength()
+
+    /** 3–4 of 5 requirements met — 2 amber segments. */
+    data object Medium : PasswordStrength()
+
+    /** All 5 requirements met — 3 green segments. */
+    data object Strong : PasswordStrength()
+}
+
+/**
+ * One row in the live requirements checklist shown below the strength bar.
+ *
+ * @property label Copy string identifying the requirement — pending Copywriter
+ *   pass (`Res.string.auth_req_*`); not referenced by the validator stub below.
+ * @property met   True once the candidate password satisfies this requirement.
+ */
+data class PasswordRequirement(val label: StringResource, val met: Boolean)
+
+/**
+ * Validates a candidate password against the five table-stakes requirements
+ * and classifies overall strength.
+ *
+ * **Pure function — no side effects, no ViewModel state, no I/O.**
+ * `AuthViewModel.onPasswordChanged` calls this synchronously and writes both
+ * outputs to `AuthUiState`.
+ *
+ * Requirements, in order: minimum 8 characters, uppercase letter, lowercase
+ * letter, number, special character (any non-alphanumeric character).
+ * Strength mapping: `met.size` 0–2 → [PasswordStrength.Weak], 3–4 →
+ * [PasswordStrength.Medium], 5 → [PasswordStrength.Strong]. An empty password
+ * returns [PasswordStrength.None] paired with an empty requirements list.
+ *
+ * **Not implemented here.** This signature is QA scaffolding so
+ * `PasswordStrengthValidatorTest` compiles and runs (red) ahead of
+ * implementation. Backend Builder implements the body per the algorithm
+ * above and the TDD; every test in this suite is expected to fail with
+ * `NotImplementedError` until then.
+ */
+object PasswordStrengthValidator {
+    fun validate(password: String): Pair<PasswordStrength, List<PasswordRequirement>> {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC18")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
@@ -5,9 +5,6 @@ import org.jetbrains.compose.resources.StringResource
 /**
  * Strength classification for a candidate password, driving the 3-segment
  * strength bar on sign-up and the reset flow's new-password step.
- *
- * See `spec-splash-auth-07222026.md` AC18 and
- * `tdd-splash-auth-07222026.md` "Data structures and algorithms".
  */
 sealed class PasswordStrength {
     /** No input yet — strength bar is hidden. */
@@ -49,7 +46,7 @@ data class PasswordRequirement(val label: StringResource, val met: Boolean)
  * **Not implemented here.** This signature is QA scaffolding so
  * `PasswordStrengthValidatorTest` compiles and runs (red) ahead of
  * implementation. Backend Builder implements the body per the algorithm
- * above and the TDD; every test in this suite is expected to fail with
+ * documented above; every test in that suite is expected to fail with
  * `NotImplementedError` until then.
  */
 object PasswordStrengthValidator {

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordScreen.kt
@@ -1,0 +1,300 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.auth_check_email_body
+import basil.composeapp.generated.resources.auth_check_email_title
+import basil.composeapp.generated.resources.auth_field_email
+import basil.composeapp.generated.resources.auth_resend_email
+import basil.composeapp.generated.resources.auth_reset_subtitle
+import basil.composeapp.generated.resources.auth_reset_title
+import basil.composeapp.generated.resources.auth_send_reset_link
+import basil.composeapp.generated.resources.cd_back
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
+import org.weekendware.basil.presentation.theme.BasilTokens
+
+/**
+ * Password reset screen — AUTH-05 (request form) before a link has been
+ * sent, AUTH-06 (check-your-email) after.
+ *
+ * @param initialEmail Prefilled from the sign-in screen's email field.
+ * @param onBack        Called from the back chevron, and from the link
+ *   below "Resend email" once a reset link has been sent.
+ */
+@Composable
+fun ResetPasswordScreen(initialEmail: String, onBack: () -> Unit) {
+    val viewModel = koinViewModel<ResetPasswordViewModel>()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    androidx.compose.runtime.LaunchedEffect(initialEmail) {
+        if (state.email.isEmpty()) viewModel.onEmailChange(initialEmail)
+    }
+
+    ResetPasswordScreenContent(
+        state         = state,
+        onEmailChange = viewModel::onEmailChange,
+        onSend        = viewModel::sendResetLink,
+        onBack        = onBack,
+    )
+}
+
+@Composable
+fun ResetPasswordScreenContent(
+    state:         ResetPasswordUiState,
+    onEmailChange: (String) -> Unit,
+    onSend:        () -> Unit,
+    onBack:        () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(BasilPalette.Cream)
+    ) {
+        ResetHeroBar(onBack = onBack)
+        if (state.isSent) {
+            ResetSentContent(email = state.email, onResend = onSend, onBack = onBack)
+        } else {
+            ResetRequestContent(state = state, onEmailChange = onEmailChange, onSend = onSend)
+        }
+    }
+}
+
+@Composable
+private fun ResetHeroBar(onBack: () -> Unit) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .background(BasilPalette.Sage600)
+            .statusBarsPadding()
+            .padding(vertical = 16.dp, horizontal = 20.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector        = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.cd_back),
+                tint               = Color.White.copy(alpha = 0.75f),
+            )
+        }
+        Spacer(Modifier.width(4.dp))
+        Box(
+            modifier = Modifier
+                .size(36.dp)
+                .clip(RoundedCornerShape(10.dp))
+                .background(Color.White.copy(alpha = 0.15f)),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(text = "b", style = MaterialTheme.typography.titleMedium, color = Color.White)
+        }
+    }
+}
+
+@Composable
+private fun ResetRequestContent(
+    state:         ResetPasswordUiState,
+    onEmailChange: (String) -> Unit,
+    onSend:        () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(horizontal = 20.dp)
+            .padding(top = 20.dp, bottom = 28.dp),
+    ) {
+        Text(
+            text  = stringResource(Res.string.auth_reset_title),
+            style = MaterialTheme.typography.headlineSmall,
+            color = BasilPalette.AuthNearBlack,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text  = stringResource(Res.string.auth_reset_subtitle),
+            style = MaterialTheme.typography.bodyMedium,
+            color = BasilPalette.AuthFieldText,
+        )
+        Spacer(Modifier.height(22.dp))
+        Text(
+            text          = stringResource(Res.string.auth_field_email).uppercase(),
+            style         = MaterialTheme.typography.labelSmall,
+            color         = BasilPalette.AuthFieldText,
+            fontWeight    = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(6.dp))
+        OutlinedTextField(
+            value           = state.email,
+            onValueChange   = onEmailChange,
+            singleLine      = true,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Done),
+            keyboardActions = KeyboardActions(onDone = { onSend() }),
+            colors          = androidx.compose.material3.OutlinedTextFieldDefaults.colors(
+                focusedContainerColor   = BasilPalette.Cream,
+                unfocusedContainerColor = BasilPalette.Cream,
+                focusedBorderColor      = BasilPalette.Sage600,
+                unfocusedBorderColor    = BasilPalette.AuthFieldBorder,
+                cursorColor             = BasilPalette.Sage600,
+            ),
+            shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+            modifier = Modifier.fillMaxWidth().height(BasilTokens.AuthFieldHeight),
+        )
+        state.error?.let { errorRes ->
+            Spacer(Modifier.height(8.dp))
+            Text(text = stringResource(errorRes), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+        Spacer(Modifier.height(8.dp))
+        if (state.isLoading) {
+            Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+                CircularProgressIndicator(color = BasilPalette.Sage600)
+            }
+        } else {
+            Button(
+                onClick  = onSend,
+                enabled  = state.canSend,
+                shape    = RoundedCornerShape(50),
+                colors   = ButtonDefaults.buttonColors(
+                    containerColor        = BasilPalette.Sage600,
+                    contentColor          = Color.White,
+                    disabledContainerColor = BasilPalette.AuthButtonMuted,
+                    disabledContentColor   = Color.White,
+                ),
+                modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+            ) {
+                Text(text = stringResource(Res.string.auth_send_reset_link), style = MaterialTheme.typography.labelLarge)
+            }
+        }
+    }
+}
+
+@Composable
+private fun ResetSentContent(email: String, onResend: () -> Unit, onBack: () -> Unit) {
+    Column(
+        modifier             = Modifier.fillMaxSize().padding(horizontal = 24.dp).padding(top = 36.dp, bottom = 40.dp),
+        horizontalAlignment  = Alignment.CenterHorizontally,
+    ) {
+        Box(
+            modifier = Modifier
+                .size(64.dp)
+                .clip(CircleShape)
+                .background(BasilPalette.AuthInfoCardBg),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(imageVector = Icons.Default.Email, contentDescription = null, tint = BasilPalette.Sage600)
+        }
+        Spacer(Modifier.height(20.dp))
+        Text(
+            text  = stringResource(Res.string.auth_check_email_title),
+            style = MaterialTheme.typography.headlineSmall,
+            color = BasilPalette.AuthNearBlack,
+        )
+        Spacer(Modifier.height(8.dp))
+        Text(
+            text  = stringResource(Res.string.auth_check_email_body),
+            style = MaterialTheme.typography.bodyMedium,
+            color = BasilPalette.AuthFieldText,
+        )
+        Spacer(Modifier.height(4.dp))
+        Text(
+            text       = email,
+            style      = MaterialTheme.typography.bodyMedium,
+            color      = BasilPalette.AuthNearBlack,
+            fontWeight = FontWeight.SemiBold,
+        )
+        Spacer(Modifier.height(28.dp))
+        OutlinedButton(
+            onClick = onResend,
+            shape   = RoundedCornerShape(50),
+            colors  = androidx.compose.material3.ButtonDefaults.outlinedButtonColors(
+                containerColor = Color.White,
+                contentColor   = BasilPalette.Sage600,
+            ),
+            border  = androidx.compose.foundation.BorderStroke(1.5.dp, BasilPalette.AuthGoogleBorder),
+            modifier = Modifier.width(200.dp).height(48.dp),
+        ) {
+            Text(text = stringResource(Res.string.auth_resend_email), style = MaterialTheme.typography.labelMedium)
+        }
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = onBack) {
+            Icon(
+                imageVector        = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.cd_back),
+                tint               = BasilPalette.AuthFieldText,
+                modifier           = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun ResetPasswordRequestPreview() {
+    BasilTheme {
+        ResetPasswordScreenContent(
+            state         = ResetPasswordUiState(email = "john@example.com"),
+            onEmailChange = {},
+            onSend        = {},
+            onBack        = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun ResetPasswordSentPreview() {
+    BasilTheme {
+        ResetPasswordScreenContent(
+            state         = ResetPasswordUiState(email = "john@example.com", isSent = true),
+            onEmailChange = {},
+            onSend        = {},
+            onBack        = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordViewModel.kt
@@ -1,0 +1,60 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.data.repository.AuthRepository
+
+/**
+ * State for the password reset request screen.
+ *
+ * @property email     Email the reset link is sent to — prefilled from the sign-in screen.
+ * @property isSent     True once a reset email has been sent for the current [email].
+ * @property isLoading  True while the send/resend network call is in flight.
+ * @property error      User-facing error string resource, or null when there is none.
+ */
+@Immutable
+data class ResetPasswordUiState(
+    val email: String = "",
+    val isSent: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: StringResource? = null,
+) {
+    val canSend: Boolean get() = email.isNotBlank() && !isLoading
+}
+
+/**
+ * ViewModel for the reset-request screen (AUTH-05 request / AUTH-06 sent).
+ * "Resend email" on the sent state re-uses [sendResetLink].
+ */
+class ResetPasswordViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(ResetPasswordUiState())
+    val state: StateFlow<ResetPasswordUiState> = _state
+
+    fun onEmailChange(value: String) = _state.update { it.copy(email = value, error = null) }
+
+    fun sendResetLink() {
+        val current = _state.value
+        if (!current.canSend) return
+
+        _state.update { it.copy(isLoading = true, error = null) }
+
+        viewModelScope.launch {
+            val result = authRepository.resetPassword(current.email)
+            result.fold(
+                onSuccess = { _state.update { it.copy(isLoading = false, isSent = true) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
+            )
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
@@ -141,6 +141,10 @@ internal object BasilPalette {
     val AuthInfoCardBg      = Color(0xFFD4E8D6)
     val AuthPlaceholderText = Color(0xFFB8B0A8)
     val AuthNearBlack       = Color(0xFF1A1816)
+    /** Amber strength-bar segment / label — [Error] doubles as the red segment. */
+    val AuthStrengthAmber = Color(0xFFE07A10)
+    /** Green strength-bar segment / label and the strong-password field border. */
+    val AuthStrengthGreen = Color(0xFF2E7D32)
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/data/repository/FakeAuthRepository.kt
@@ -24,6 +24,7 @@ class FakeAuthRepository : AuthRepository {
     var googleSignInResult: Result<Unit> = Result.success(Unit)
     var appleSignInResult: Result<Unit> = Result.success(Unit)
     var resetPasswordResult: Result<Unit> = Result.success(Unit)
+    var updatePasswordResult: Result<Unit> = Result.success(Unit)
     var resendVerificationResult: Result<Unit> = Result.success(Unit)
     var registerPasskeyResult: Result<Unit> = Result.success(Unit)
     var signInWithPasskeyResult: Result<Unit> = Result.success(Unit)
@@ -41,6 +42,10 @@ class FakeAuthRepository : AuthRepository {
     var lastResetPasswordEmail: String? = null
         private set
     var lastHandledDeepLink: String? = null
+        private set
+    var updatePasswordCallCount: Int = 0
+        private set
+    var lastUpdatedPassword: String? = null
         private set
 
     fun setSignedIn(value: Boolean) {
@@ -115,4 +120,10 @@ class FakeAuthRepository : AuthRepository {
     }
 
     override fun lastUsedEmail(): String? = storedLastUsedEmail
+
+    override suspend fun updatePassword(newPassword: String): Result<Unit> {
+        updatePasswordCallCount++
+        lastUpdatedPassword = newPassword
+        return updatePasswordResult
+    }
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -115,11 +115,19 @@ class PasswordStrengthValidatorTest {
     }
 
     @Test
-    fun `requirements are returned in a stable order — length, uppercase, lowercase, number, special`() {
-        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
-        assertEquals(5, requirements.size)
-        // Order asserted positionally per the TDD's documented sequence;
-        // see the boundary tests above for what each index represents.
+    fun `requirements list has exactly one entry per requirement, in a fixed order`() {
+        // An all-digit, 8-character password meets only length and number —
+        // no letters means no uppercase/lowercase, and digits don't count as
+        // special characters. met=true should land at exactly those two
+        // positions — length (0) and number (3) — pinning down the actual
+        // order (length, uppercase, lowercase, number, special), not just
+        // the list's size; the individual boundary tests above each isolate
+        // one index but never assert the full five-position layout at once.
+        val (_, requirements) = PasswordStrengthValidator.validate("12345678")
+        assertEquals(
+            listOf(true, false, false, true, false),
+            requirements.map { it.met },
+        )
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -5,13 +5,13 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 /**
- * QA test suite for [PasswordStrengthValidator], written from
- * `tdd-splash-auth-07222026.md` (AC18) ahead of implementation.
+ * QA test suite for [PasswordStrengthValidator], written ahead of
+ * implementation per the team's test-first process. Covers threshold
+ * classification (Weak/Medium/Strong), the length and special-character
+ * boundaries, and requirement-list shape and determinism.
  *
  * All cases are expected to fail with `NotImplementedError` until Backend
- * Builder implements [PasswordStrengthValidator.validate]. See
- * `tests-splash-auth-07232026.md` for the full QA plan — this file covers
- * SPA-052 through SPA-060 and SPA-062.
+ * Builder implements [PasswordStrengthValidator.validate].
  *
  * Deliberately does not assert on [PasswordRequirement.label] — copy is
  * pending a Copywriter pass and is out of scope for this validator's

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -1,0 +1,132 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [PasswordStrengthValidator], written from
+ * `tdd-splash-auth-07222026.md` (AC18) ahead of implementation.
+ *
+ * All cases are expected to fail with `NotImplementedError` until Backend
+ * Builder implements [PasswordStrengthValidator.validate]. See
+ * `tests-splash-auth-07232026.md` for the full QA plan — this file covers
+ * SPA-052 through SPA-060 and SPA-062.
+ *
+ * Deliberately does not assert on [PasswordRequirement.label] — copy is
+ * pending a Copywriter pass and is out of scope for this validator's
+ * contract. Tests assert only on strength classification, `met` values,
+ * and list shape/order.
+ */
+class PasswordStrengthValidatorTest {
+
+    @Test
+    fun `empty password returns None with an empty requirements list`() {
+        val (strength, requirements) = PasswordStrengthValidator.validate("")
+        assertEquals(PasswordStrength.None, strength)
+        assertTrue(requirements.isEmpty())
+    }
+
+    @Test
+    fun `password meeting zero requirements is Weak`() {
+        // Below length, no uppercase, no digit, no special char.
+        val (strength, requirements) = PasswordStrengthValidator.validate("abc")
+        assertEquals(PasswordStrength.Weak, strength)
+        assertEquals(5, requirements.size)
+        assertTrue(requirements.none { it.met })
+    }
+
+    @Test
+    fun `password meeting exactly two requirements is Weak`() {
+        // lowercase + length, nothing else.
+        val (strength, _) = PasswordStrengthValidator.validate("abcdefgh")
+        assertEquals(PasswordStrength.Weak, strength)
+    }
+
+    @Test
+    fun `password meeting exactly three requirements is Medium`() {
+        // length + lowercase + uppercase.
+        val (strength, _) = PasswordStrengthValidator.validate("Abcdefgh")
+        assertEquals(PasswordStrength.Medium, strength)
+    }
+
+    @Test
+    fun `password meeting exactly four requirements is Medium`() {
+        // length + lowercase + uppercase + digit, no special char.
+        val (strength, _) = PasswordStrengthValidator.validate("Abcdefg1")
+        assertEquals(PasswordStrength.Medium, strength)
+    }
+
+    @Test
+    fun `password meeting all five requirements is Strong`() {
+        val (strength, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(PasswordStrength.Strong, strength)
+        assertTrue(requirements.all { it.met })
+    }
+
+    @Test
+    fun `length requirement fails at seven characters and passes at eight`() {
+        val (_, sevenChars) = PasswordStrengthValidator.validate("Abcdef1!".dropLast(1))
+        assertEquals(false, sevenChars[0].met)
+
+        val (_, eightChars) = PasswordStrengthValidator.validate("Abcdef1!")
+        assertEquals(true, eightChars[0].met)
+    }
+
+    @Test
+    fun `uppercase requirement is met only when an uppercase letter is present`() {
+        val (_, withoutUpper) = PasswordStrengthValidator.validate("abcdefg1!")
+        assertEquals(false, withoutUpper[1].met)
+
+        val (_, withUpper) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(true, withUpper[1].met)
+    }
+
+    @Test
+    fun `lowercase requirement is met only when a lowercase letter is present`() {
+        val (_, withoutLower) = PasswordStrengthValidator.validate("ABCDEFG1!")
+        assertEquals(false, withoutLower[2].met)
+
+        val (_, withLower) = PasswordStrengthValidator.validate("ABCDEFGa1!")
+        assertEquals(true, withLower[2].met)
+    }
+
+    @Test
+    fun `number requirement is met only when a digit is present`() {
+        val (_, withoutDigit) = PasswordStrengthValidator.validate("Abcdefgh!")
+        assertEquals(false, withoutDigit[3].met)
+
+        val (_, withDigit) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(true, withDigit[3].met)
+    }
+
+    @Test
+    fun `special character requirement accepts any non-alphanumeric character`() {
+        for (symbol in listOf('!', '-', '#', '@', '_', '.')) {
+            val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1$symbol")
+            assertTrue(requirements[4].met, "Expected '$symbol' to satisfy the special-character requirement")
+        }
+    }
+
+    @Test
+    fun `special character requirement is not met without one`() {
+        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg12")
+        assertEquals(false, requirements[4].met)
+    }
+
+    @Test
+    fun `requirements are returned in a stable order — length, uppercase, lowercase, number, special`() {
+        val (_, requirements) = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(5, requirements.size)
+        // Order asserted positionally per the TDD's documented sequence;
+        // see the boundary tests above for what each index represents.
+    }
+
+    @Test
+    fun `validate is deterministic for the same input`() {
+        val first = PasswordStrengthValidator.validate("Abcdefg1!")
+        val second = PasswordStrengthValidator.validate("Abcdefg1!")
+        assertEquals(first.first, second.first)
+        assertEquals(first.second.map { it.met }, second.second.map { it.met })
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/NewPasswordViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/NewPasswordViewModelTest.kt
@@ -1,0 +1,130 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [NewPasswordViewModel]. Every case touching
+ * [NewPasswordViewModel.onPasswordChange] is expected to fail with
+ * `NotImplementedError` until Backend implements
+ * [PasswordStrengthValidator.validate] — that dependency is scaffolded
+ * but not yet implemented, and this ViewModel calls it on every
+ * keystroke by design (live strength feedback).
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class NewPasswordViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+    private lateinit var viewModel: NewPasswordViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+        viewModel = NewPasswordViewModel(repo)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state has no strength, empty fields, cannot submit`() {
+        val state = viewModel.state.value
+        assertEquals("", state.password)
+        assertEquals("", state.confirmPassword)
+        assertEquals(PasswordStrength.None, state.passwordStrength)
+        assertFalse(state.isPasswordVisible)
+        assertFalse(state.passwordsMatch)
+        assertFalse(state.canSubmit)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `passwordsMatch is false when confirm field is empty`() {
+        // Does not touch onPasswordChange — safe to assert without the validator.
+        viewModel.onConfirmPasswordChange("")
+        assertFalse(viewModel.state.value.passwordsMatch)
+    }
+
+    @Test
+    fun `onTogglePasswordVisibility flips the shared flag`() {
+        assertFalse(viewModel.state.value.isPasswordVisible)
+        viewModel.onTogglePasswordVisibility()
+        assertTrue(viewModel.state.value.isPasswordVisible)
+    }
+
+    @Test
+    fun `onPasswordChange updates strength and requirements from the validator`() {
+        viewModel.onPasswordChange("Abcdefg1!")
+        val state = viewModel.state.value
+        assertEquals(PasswordStrength.Strong, state.passwordStrength)
+        assertTrue(state.passwordRequirements.all { it.met })
+    }
+
+    @Test
+    fun `canSubmit requires Strong strength even when the fields match`() {
+        viewModel.onPasswordChange("weak")
+        viewModel.onConfirmPasswordChange("weak")
+        assertFalse(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `canSubmit is false when strong but the fields do not match`() {
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onConfirmPasswordChange("Different1!")
+        assertFalse(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `canSubmit is true when strong and the fields match`() {
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onConfirmPasswordChange("Abcdefg1!")
+        assertTrue(viewModel.state.value.canSubmit)
+    }
+
+    @Test
+    fun `submit does nothing when canSubmit is false`() = runTest {
+        viewModel.submit()
+        assertEquals(0, repo.updatePasswordCallCount)
+    }
+
+    @Test
+    fun `successful submit clears loading and records the new password`() = runTest {
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onConfirmPasswordChange("Abcdefg1!")
+        viewModel.submit()
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertEquals("Abcdefg1!", repo.lastUpdatedPassword)
+    }
+
+    @Test
+    fun `failed submit surfaces an error`() = runTest {
+        repo.updatePasswordResult = Result.failure(Exception("session expired"))
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onConfirmPasswordChange("Abcdefg1!")
+        viewModel.submit()
+
+        assertEquals(Res.string.error_auth_failed, viewModel.state.value.error)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/ResetPasswordViewModelTest.kt
@@ -1,0 +1,103 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ResetPasswordViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+    private lateinit var viewModel: ResetPasswordViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+        viewModel = ResetPasswordViewModel(repo)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is not sent, nothing entered`() {
+        val state = viewModel.state.value
+        assertEquals("", state.email)
+        assertFalse(state.isSent)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `canSend is false when email is blank`() {
+        assertFalse(viewModel.state.value.canSend)
+    }
+
+    @Test
+    fun `sendResetLink does nothing when the email is blank`() = runTest {
+        viewModel.sendResetLink()
+        assertEquals(0, repo.resetPasswordCallCount)
+    }
+
+    @Test
+    fun `successful send sets isSent and records the email`() = runTest {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.sendResetLink()
+
+        val state = viewModel.state.value
+        assertTrue(state.isSent)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertEquals("user@test.com", repo.lastResetPasswordEmail)
+    }
+
+    @Test
+    fun `failed send surfaces an error and does not set isSent`() = runTest {
+        repo.resetPasswordResult = Result.failure(Exception("rate limited"))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.sendResetLink()
+
+        val state = viewModel.state.value
+        assertFalse(state.isSent)
+        assertEquals(Res.string.error_auth_failed, state.error)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `resend calls sendResetLink again, incrementing the call count`() = runTest {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.sendResetLink()
+        assertEquals(1, repo.resetPasswordCallCount)
+
+        viewModel.sendResetLink() // "Resend email" reuses the same action
+        assertEquals(2, repo.resetPasswordCallCount)
+    }
+
+    @Test
+    fun `onEmailChange clears an existing error`() = runTest {
+        repo.resetPasswordResult = Result.failure(Exception("error"))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.sendResetLink()
+        assertEquals(Res.string.error_auth_failed, viewModel.state.value.error)
+
+        viewModel.onEmailChange("new@test.com")
+        assertNull(viewModel.state.value.error)
+    }
+}


### PR DESCRIPTION
## Summary
Depends on #61 (email-first auth screen) and #53 (PasswordStrengthValidator) — merged in locally. Matches AUTH-05 (request), AUTH-06 (link sent), AUTH-07 (new password via deep link) in the mockup, and completes "Forgot password?" on the sign-in step — it was a dead \`Text\` label since the auth screen rewrite in #61.

## What's here
- **New \`AuthRepository\` method**: \`updatePassword(newPassword)\` — the TDD's \`client.auth.updateUser { password = newPassword }\` step, which I missed when originally expanding the interface in #55. Same pattern: \`TODO()\` in \`SupabaseAuthRepository\`, fully implemented in \`FakeAuthRepository\`.
- **\`ResetPasswordViewModel\`/\`ResetPasswordScreen\`** (AUTH-05/06) — fully green, doesn't touch anything still-\`TODO()\`'d beyond \`resetPassword()\` itself.
- **\`NewPasswordViewModel\`/\`NewPasswordScreen\`** (AUTH-07) — live password-strength feedback via \`PasswordStrengthValidator\` on every keystroke, matching the mockup's segmented bar + requirements checklist.
- **\`AuthFlowScreen\`** — new local-navigation wrapper (plain composable state, same pattern as \`AuthenticatedRoot\`'s tab switching, no nav library) that actually makes "Forgot password?" reachable. \`App.kt\` now calls this instead of \`AuthScreen\` directly.

## Known red state — by design
6 of 10 \`NewPasswordViewModelTest\` cases fail: every one touching \`onPasswordChange\` calls the still-\`TODO()\`'d \`PasswordStrengthValidator\` (live feedback, not just on submit, so this is unavoidable). Same situation already flagged for the Google/Apple buttons and \`SessionViewModel\` in earlier branches — the UI and wiring are real, the backend behind them isn't built yet.

## Known gap — flagged, not silently skipped
\`NewPasswordScreen\` is built and tested standalone but **not wired into app routing**. Reaching it depends on \`DeepLinkHandler\` actually triggering navigation on a successful deep-link exchange — a separate, not-yet-built event bridge from the data layer to the UI layer. Ready for that wiring once it exists.

## Bug caught and fixed along the way
While building these screens I re-checked the mockup's actual markup and caught a real fidelity bug in #61: the auth screen's hero band was using a row/compact layout AUTH-02 and AUTH-03 never actually have — pushed as a follow-up commit to that PR directly.

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\`, \`:composeApp:compileDevDebugKotlinAndroid\`, \`:composeApp:compileKotlinDesktop\` — all clean
- [x] \`ResetPasswordViewModelTest\` — 7/7 green
- [x] \`NewPasswordViewModelTest\` — 4/10 green (rest red as documented)
- [x] No regressions elsewhere
- [ ] Manual: verify against the mockup visually (not verifiable from this environment)
- [ ] Copywriter pass on new strings