### PR TITLE
Add verification banner (chat) and real soft-block wall content

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -40,6 +40,15 @@
     <string name="auth_field_confirm_password">Confirm password</string>
     <string name="auth_set_new_password">Set new password</string>
 
+    <!-- ── Email verification wall / banner ──────────────────── -->
+    <string name="auth_verify_wall_title">Verify your email</string>
+    <string name="auth_verify_wall_body">To keep your account secure, we need to confirm your email address.</string>
+    <string name="auth_verify_wall_sent_to">We sent a verification link to</string>
+    <string name="auth_resend_verification">Resend verification email</string>
+    <string name="auth_sign_out_different_account">Sign out and use a different account</string>
+    <string name="auth_verify_banner_text">Please verify your email to keep your account safe.</string>
+    <string name="auth_verify_banner_resend">Resend</string>
+
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>
     <string name="nav_chat">Chat</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -57,13 +57,16 @@ import basil.composeapp.generated.resources.nav_profile
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.presentation.auth.AuthScreen
+import org.weekendware.basil.presentation.auth.VerificationWallScreen
 import org.weekendware.basil.presentation.chat.ChatScreen
 import org.weekendware.basil.presentation.more.MoreScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingViewModel
 import org.weekendware.basil.presentation.profile.ProfileScreen
+import org.weekendware.basil.presentation.session.AuthenticatedDestination
 import org.weekendware.basil.presentation.session.SessionState
 import org.weekendware.basil.presentation.session.SessionViewModel
+import org.weekendware.basil.presentation.session.authenticatedDestination
 import org.weekendware.basil.presentation.settings.SettingsScreen
 import org.weekendware.basil.presentation.splash.SplashScreen
 import org.weekendware.basil.presentation.theme.BasilTheme
@@ -104,10 +107,15 @@ fun App() {
                 if (splashVisible) {
                     SplashScreen(onFadeComplete = { splashDone = true })
                 } else {
-                    when (sessionState) {
+                    when (val session = sessionState) {
                         SessionState.Unauthenticated -> AuthScreen()
-                        SessionState.Authenticated   -> AuthenticatedRoot(themeHour = themeHour)
-                        SessionState.Loading         -> Box(Modifier.fillMaxSize())
+                        is SessionState.Authenticated -> when (authenticatedDestination(session)) {
+                            AuthenticatedDestination.Normal ->
+                                AuthenticatedRoot(themeHour = themeHour)
+                            AuthenticatedDestination.VerificationWall ->
+                                VerificationWallScreen()
+                        }
+                        SessionState.Loading -> Box(Modifier.fillMaxSize())
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -23,6 +23,9 @@ import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.GetUserUseCase
 import org.weekendware.basil.domain.usecase.SendMessageUseCase
 import org.weekendware.basil.presentation.auth.AuthViewModel
+import org.weekendware.basil.presentation.auth.NewPasswordViewModel
+import org.weekendware.basil.presentation.auth.ResetPasswordViewModel
+import org.weekendware.basil.presentation.auth.VerificationWallViewModel
 import org.weekendware.basil.presentation.chat.ChatViewModel
 import org.weekendware.basil.presentation.onboarding.OnboardingViewModel
 import org.weekendware.basil.presentation.profile.ProfileViewModel
@@ -65,9 +68,12 @@ val onboardingModule = module {
 val sharedModule = module {
     viewModel { SessionViewModel(get()) }
     viewModel { AuthViewModel(get()) }
+    viewModel { ResetPasswordViewModel(get()) }
+    viewModel { NewPasswordViewModel(get()) }
+    viewModel { VerificationWallViewModel(get()) }
     viewModel { OnboardingViewModel(get(), get(), get(), get()) }
     viewModel { ProfileViewModel(get(), get(), get()) }
-    viewModel { ChatViewModel(get()) }
+    viewModel { ChatViewModel(get(), get()) }
     viewModel { SettingsViewModel() }
     viewModel { BasilThemeViewModel() }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
@@ -1,16 +1,194 @@
 package org.weekendware.basil.presentation.auth
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBarsPadding
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Lock
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.app_name
+import basil.composeapp.generated.resources.auth_resend_verification
+import basil.composeapp.generated.resources.auth_sign_out_different_account
+import basil.composeapp.generated.resources.auth_verify_wall_body
+import basil.composeapp.generated.resources.auth_verify_wall_sent_to
+import basil.composeapp.generated.resources.auth_verify_wall_title
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
+import org.weekendware.basil.presentation.theme.BasilTokens
 
 /**
  * Shown when a user has gone 30+ days without verifying their email — the
- * soft-block wall. Blank placeholder pending UI design; Frontend Builder
- * fills this in with the verify/resend/sign-out content.
+ * soft-block wall (AUTH-09). Full screen, no dismiss affordance: the only
+ * two exits are verifying (outside the app, via the emailed link) or
+ * signing out to try a different account.
  */
 @Composable
 fun VerificationWallScreen(modifier: Modifier = Modifier) {
-    Box(modifier = modifier.fillMaxSize())
+    val viewModel = koinViewModel<VerificationWallViewModel>()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    VerificationWallScreenContent(
+        state      = state,
+        onResend   = viewModel::onResend,
+        onSignOut  = viewModel::onSignOut,
+        modifier   = modifier,
+    )
+}
+
+@Composable
+fun VerificationWallScreenContent(
+    state:     VerificationWallUiState,
+    onResend:  () -> Unit,
+    onSignOut: () -> Unit,
+    modifier:  Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxSize().background(BasilPalette.Cream)) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(BasilPalette.Sage600)
+                .statusBarsPadding()
+                .padding(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 20.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(BasilTokens.AuthLogoSize)
+                    .clip(RoundedCornerShape(BasilTokens.AuthLogoCorner))
+                    .background(Color.White.copy(alpha = 0.15f)),
+                contentAlignment = Alignment.Center,
+            ) {
+                Text(text = "b", style = MaterialTheme.typography.headlineMedium, color = Color.White)
+            }
+            Spacer(Modifier.height(8.dp))
+            Text(text = stringResource(Res.string.app_name), style = MaterialTheme.typography.displaySmall, color = Color.White)
+        }
+
+        Column(
+            modifier            = Modifier.fillMaxSize().padding(horizontal = 24.dp).padding(top = 20.dp, bottom = 40.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Box(
+                modifier = Modifier
+                    .size(64.dp)
+                    .clip(CircleShape)
+                    .background(BasilPalette.AuthInfoCardBg),
+                contentAlignment = Alignment.Center,
+            ) {
+                Icon(imageVector = Icons.Default.Lock, contentDescription = null, tint = BasilPalette.Sage600)
+            }
+            Spacer(Modifier.height(20.dp))
+            Text(
+                text      = stringResource(Res.string.auth_verify_wall_title),
+                style     = MaterialTheme.typography.headlineSmall,
+                color     = BasilPalette.AuthNearBlack,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(10.dp))
+            Text(
+                text      = stringResource(Res.string.auth_verify_wall_body),
+                style     = MaterialTheme.typography.bodyMedium,
+                color     = BasilPalette.AuthFieldText,
+                textAlign = TextAlign.Center,
+            )
+            Spacer(Modifier.height(6.dp))
+            Text(
+                text      = stringResource(Res.string.auth_verify_wall_sent_to),
+                style     = MaterialTheme.typography.bodyMedium,
+                color     = BasilPalette.AuthFieldText,
+                textAlign = TextAlign.Center,
+            )
+            Text(
+                text       = state.email,
+                style      = MaterialTheme.typography.bodyMedium,
+                color      = BasilPalette.Sage600,
+                fontWeight = FontWeight.SemiBold,
+                textAlign  = TextAlign.Center,
+            )
+            Spacer(Modifier.height(28.dp))
+            if (state.isLoading) {
+                CircularProgressIndicator(color = BasilPalette.Sage600)
+            } else {
+                Button(
+                    onClick  = onResend,
+                    enabled  = state.canResend,
+                    shape    = RoundedCornerShape(50),
+                    colors   = ButtonDefaults.buttonColors(
+                        containerColor        = BasilPalette.Sage600,
+                        contentColor          = Color.White,
+                        disabledContainerColor = BasilPalette.AuthButtonMuted,
+                        disabledContentColor   = Color.White,
+                    ),
+                    modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+                ) {
+                    Text(text = stringResource(Res.string.auth_resend_verification), style = MaterialTheme.typography.labelLarge)
+                }
+            }
+            Spacer(Modifier.height(16.dp))
+            TextButton(onClick = onSignOut) {
+                Text(
+                    text  = stringResource(Res.string.auth_sign_out_different_account),
+                    style = MaterialTheme.typography.labelMedium,
+                    color = BasilPalette.Sage600,
+                )
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun VerificationWallPreview() {
+    BasilTheme {
+        VerificationWallScreenContent(
+            state     = VerificationWallUiState(email = "john@example.com"),
+            onResend  = {},
+            onSignOut = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun VerificationWallCooldownPreview() {
+    BasilTheme {
+        VerificationWallScreenContent(
+            state     = VerificationWallUiState(email = "john@example.com", canResend = false),
+            onResend  = {},
+            onSignOut = {},
+        )
+    }
 }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallScreen.kt
@@ -1,0 +1,16 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * Shown when a user has gone 30+ days without verifying their email — the
+ * soft-block wall. Blank placeholder pending UI design; Frontend Builder
+ * fills this in with the verify/resend/sign-out content.
+ */
+@Composable
+fun VerificationWallScreen(modifier: Modifier = Modifier) {
+    Box(modifier = modifier.fillMaxSize())
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/VerificationWallViewModel.kt
@@ -1,0 +1,58 @@
+package org.weekendware.basil.presentation.auth
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.weekendware.basil.data.repository.AuthRepository
+
+/**
+ * State for [VerificationWallScreen] — the full-screen, non-dismissible
+ * soft block shown once a user has gone 30+ days without verifying.
+ *
+ * @property email       The signed-in user's email, shown so they know
+ *   which address to check.
+ * @property canResend   False for 60 seconds after a resend, mirroring the
+ *   same client-side cooldown used elsewhere for resend actions.
+ */
+@Immutable
+data class VerificationWallUiState(
+    val email: String = "",
+    val isLoading: Boolean = false,
+    val canResend: Boolean = true,
+)
+
+/**
+ * ViewModel for [VerificationWallScreen]. The wall has exactly two exits:
+ * verifying the email (handled outside the app, via the emailed link — this
+ * screen just re-checks on next [org.weekendware.basil.presentation.session.SessionViewModel]
+ * recomposition) or signing out to try a different account.
+ */
+class VerificationWallViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(VerificationWallUiState(email = authRepository.currentUserEmail().orEmpty()))
+    val state: StateFlow<VerificationWallUiState> = _state
+
+    fun onResend() {
+        if (!_state.value.canResend) return
+        _state.update { it.copy(isLoading = true) }
+        viewModelScope.launch {
+            authRepository.resendVerificationEmail()
+            _state.update { it.copy(isLoading = false, canResend = false) }
+            delay(60_000)
+            _state.update { it.copy(canResend = true) }
+        }
+    }
+
+    fun onSignOut() {
+        viewModelScope.launch {
+            authRepository.signOut()
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatScreen.kt
@@ -1,7 +1,9 @@
 package org.weekendware.basil.presentation.chat
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +26,8 @@ import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.Send
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -39,9 +43,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.auth_verify_banner_resend
+import basil.composeapp.generated.resources.auth_verify_banner_text
+import basil.composeapp.generated.resources.cd_close
 import basil.composeapp.generated.resources.cd_send_message
 import basil.composeapp.generated.resources.chat_empty_subtitle
 import basil.composeapp.generated.resources.chat_empty_title
@@ -50,6 +58,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.viewmodel.koinViewModel
 import org.weekendware.basil.domain.model.ChatMessage
+import org.weekendware.basil.presentation.theme.BasilPalette
 import org.weekendware.basil.presentation.theme.BasilTheme
 import org.weekendware.basil.presentation.theme.basilSpacing
 
@@ -86,10 +95,12 @@ fun ChatScreen(initialGreeting: String? = null) {
     }
 
     ChatScreenContent(
-        state             = state,
-        snackbarHostState = snackbarHostState,
-        onInputChange     = viewModel::onInputChange,
-        onSend            = viewModel::sendMessage
+        state                = state,
+        snackbarHostState    = snackbarHostState,
+        onInputChange        = viewModel::onInputChange,
+        onSend               = viewModel::sendMessage,
+        onDismissBanner      = viewModel::onDismissVerificationBanner,
+        onResendVerification = viewModel::onResendVerification,
     )
 }
 
@@ -103,6 +114,8 @@ fun ChatScreenContent(
     snackbarHostState: SnackbarHostState = remember { SnackbarHostState() },
     onInputChange: (String) -> Unit,
     onSend: () -> Unit,
+    onDismissBanner: () -> Unit = {},
+    onResendVerification: () -> Unit = {},
     modifier: Modifier = Modifier
 ) {
     val listState = rememberLazyListState()
@@ -120,6 +133,14 @@ fun ChatScreenContent(
                 .fillMaxSize()
                 .imePadding()
         ) {
+            if (state.showVerificationBanner) {
+                VerificationBanner(
+                    isResending = state.isResendingVerification,
+                    onResend    = onResendVerification,
+                    onDismiss   = onDismissBanner,
+                )
+            }
+
             // ── Message list ──────────────────────────────────────
             Box(modifier = Modifier.weight(1f)) {
                 if (state.messages.isEmpty()) {
@@ -165,6 +186,75 @@ fun ChatScreenContent(
             hostState = snackbarHostState,
             modifier  = Modifier.align(Alignment.BottomCenter),
         )
+    }
+}
+
+/**
+ * Dismissible banner shown above the chat when the signed-in user's email
+ * is unverified but they're still within the 30-day grace period (past
+ * that, [org.weekendware.basil.presentation.auth.VerificationWallScreen]
+ * replaces the whole screen instead — this banner never appears there).
+ */
+@Composable
+internal fun VerificationBanner(
+    isResending: Boolean,
+    onResend:    () -> Unit,
+    onDismiss:   () -> Unit,
+    modifier:    Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier
+            .fillMaxWidth()
+            .background(BasilPalette.VerifyBannerBg)
+            .border(
+                BorderStroke(1.5.dp, BasilPalette.VerifyBannerBorder),
+            )
+            .padding(horizontal = 16.dp, vertical = 11.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+    ) {
+        Box(
+            modifier = Modifier
+                .size(6.dp)
+                .clip(CircleShape)
+                .background(BasilPalette.VerifyBannerDot)
+        )
+        Text(
+            text     = stringResource(Res.string.auth_verify_banner_text),
+            style    = MaterialTheme.typography.bodySmall,
+            color    = BasilPalette.VerifyBannerText,
+            modifier = Modifier.weight(1f),
+        )
+        if (isResending) {
+            CircularProgressIndicator(
+                modifier   = Modifier.size(14.dp),
+                strokeWidth = 2.dp,
+                color      = BasilPalette.VerifyBannerText,
+            )
+        } else {
+            Text(
+                text       = stringResource(Res.string.auth_verify_banner_resend),
+                style      = MaterialTheme.typography.labelMedium,
+                color      = BasilPalette.Sage600,
+                fontWeight = FontWeight.SemiBold,
+                modifier   = Modifier.clickable(onClick = onResend),
+            )
+        }
+        Box(
+            modifier = Modifier
+                .size(18.dp)
+                .clip(CircleShape)
+                .background(BasilPalette.VerifyBannerDot.copy(alpha = 0.15f))
+                .clickable(onClick = onDismiss),
+            contentAlignment = Alignment.Center,
+        ) {
+            Icon(
+                imageVector        = Icons.Default.Close,
+                contentDescription = stringResource(Res.string.cd_close),
+                tint               = BasilPalette.VerifyBannerText,
+                modifier           = Modifier.size(10.dp),
+            )
+        }
     }
 }
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/chat/ChatViewModel.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.data.repository.AuthRepository
 import org.weekendware.basil.domain.model.ChatMessage
 import org.weekendware.basil.domain.usecase.SendMessageUseCase
 import kotlin.uuid.ExperimentalUuidApi
@@ -27,6 +28,13 @@ import kotlin.uuid.Uuid
  *                      the user sends a message (shows a typing indicator).
  * @property error      Non-null when the last send attempt failed; cleared by
  *                      calling [ChatViewModel.clearError].
+ * @property showVerificationBanner True when the signed-in user's email is
+ *   unverified and they haven't dismissed the banner yet this session.
+ *   Never true once [org.weekendware.basil.presentation.auth.VerificationWallScreen]
+ *   has taken over (that's a separate, non-dismissible screen for the
+ *   30-day-and-older case) — this banner is only for users still within
+ *   the grace period.
+ * @property isResendingVerification True while a resend request is in flight.
  */
 @Stable
 data class ChatState(
@@ -34,6 +42,8 @@ data class ChatState(
     val input: String = "",
     val isLoading: Boolean = false,
     val error: StringResource? = null,
+    val showVerificationBanner: Boolean = false,
+    val isResendingVerification: Boolean = false,
 )
 
 /**
@@ -43,18 +53,25 @@ data class ChatState(
  * AI backend via [SendMessageUseCase]. Each text delta emitted by the use case
  * is appended to the last assistant message in [state].
  *
- * @param sendMessage    Use case that streams the assistant's reply.
- * @param coroutineScope Scope for async operations. Defaults to [viewModelScope]
- *                       when null. Override in tests with a [TestScope].
+ * @param sendMessage     Use case that streams the assistant's reply.
+ * @param authRepository  Read once on init to decide [ChatState.showVerificationBanner] —
+ *                        this screen is only ever shown to a verified user or one still
+ *                        within the 30-day grace period (the wall takes over past that),
+ *                        so no re-check against days-since-signup is needed here.
+ * @param coroutineScope  Scope for async operations. Defaults to [viewModelScope]
+ *                        when null. Override in tests with a [TestScope].
  */
 class ChatViewModel(
     private val sendMessage: SendMessageUseCase,
+    private val authRepository: AuthRepository,
     coroutineScope: CoroutineScope? = null,
 ) : ViewModel() {
 
     private val scope = coroutineScope ?: viewModelScope
 
-    private val _state = MutableStateFlow(ChatState())
+    private val _state = MutableStateFlow(
+        ChatState(showVerificationBanner = !authRepository.isEmailVerified())
+    )
 
     /** The current UI state. Observed by [ChatScreen] to drive recomposition. */
     val state: StateFlow<ChatState> = _state
@@ -158,6 +175,20 @@ class ChatViewModel(
     /** Dismisses the current error banner. */
     fun clearError() {
         _state.update { it.copy(error = null) }
+    }
+
+    /** Dismisses the verification banner for the rest of this session. */
+    fun onDismissVerificationBanner() {
+        _state.update { it.copy(showVerificationBanner = false) }
+    }
+
+    /** Resends the verification email. Does not dismiss the banner — the user does that separately. */
+    fun onResendVerification() {
+        _state.update { it.copy(isResendingVerification = true) }
+        scope.launch {
+            authRepository.resendVerificationEmail()
+            _state.update { it.copy(isResendingVerification = false) }
+        }
     }
 
     /**

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
@@ -13,12 +13,39 @@ sealed interface SessionState {
     /** Supabase is restoring the session from storage — do not navigate yet. */
     data object Loading : SessionState
 
-    /** A valid session exists; the user is signed in. */
-    data object Authenticated : SessionState
+    /**
+     * A valid session exists; the user is signed in.
+     *
+     * @property isEmailVerified True once the user has confirmed their email.
+     * @property daysSinceSignup Elapsed days since account creation — used to
+     *   decide whether an unverified user is inside the grace period or past
+     *   the soft-block threshold.
+     */
+    data class Authenticated(
+        val isEmailVerified: Boolean,
+        val daysSinceSignup: Long,
+    ) : SessionState
 
     /** No session — the user must sign in. */
     data object Unauthenticated : SessionState
 }
+
+/** Where an authenticated user lands once their verification status is known. */
+enum class AuthenticatedDestination { Normal, VerificationWall }
+
+/**
+ * Pure routing decision for an authenticated user. A user unverified for 30
+ * or more days is walled off until they verify or request a new email;
+ * everyone else — verified, or unverified but still within the grace
+ * period — reaches the normal authenticated experience. Unverified-within-grace
+ * users see a dismissible banner inside that experience, not this wall.
+ */
+fun authenticatedDestination(state: SessionState.Authenticated): AuthenticatedDestination =
+    if (!state.isEmailVerified && state.daysSinceSignup >= 30) {
+        AuthenticatedDestination.VerificationWall
+    } else {
+        AuthenticatedDestination.Normal
+    }
 
 /**
  * App-root ViewModel that owns the single source of truth for auth state.
@@ -32,12 +59,19 @@ sealed interface SessionState {
  * the SDK restores a stored session on cold start.
  */
 class SessionViewModel(
-    authRepository: AuthRepository
+    private val authRepository: AuthRepository
 ) : ViewModel() {
 
     val state: StateFlow<SessionState> = authRepository.sessionFlow
         .map { isSignedIn ->
-            if (isSignedIn) SessionState.Authenticated else SessionState.Unauthenticated
+            if (isSignedIn) {
+                SessionState.Authenticated(
+                    isEmailVerified = authRepository.isEmailVerified(),
+                    daysSinceSignup = authRepository.daysSinceSignup(),
+                )
+            } else {
+                SessionState.Unauthenticated
+            }
         }
         .stateIn(
             scope = viewModelScope,

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/theme/BasilColors.kt
@@ -145,6 +145,13 @@ internal object BasilPalette {
     val AuthStrengthAmber = Color(0xFFE07A10)
     /** Green strength-bar segment / label and the strong-password field border. */
     val AuthStrengthGreen = Color(0xFF2E7D32)
+
+    // Verification banner (on the chat screen) — literal, hand-picked, distinct
+    // from the auth-screen colors above since this lives on an in-app surface.
+    val VerifyBannerBg     = Color(0xFFFFF8ED)
+    val VerifyBannerBorder = Color(0xFFE8C97A)
+    val VerifyBannerDot    = Color(0xFFC8962A)
+    val VerifyBannerText   = Color(0xFF7A5A18)
 }
 
 // ─────────────────────────────────────────────────────────────

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
@@ -29,7 +29,7 @@ class SplashGateTest {
     @Test
     fun `shows splash when session resolved but fade not yet complete`() {
         assertTrue(shouldShowSplash(SessionState.Unauthenticated, splashFadeDone = false))
-        assertTrue(shouldShowSplash(SessionState.Authenticated,   splashFadeDone = false))
+        assertTrue(shouldShowSplash(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0),   splashFadeDone = false))
     }
 
     @Test
@@ -39,6 +39,6 @@ class SplashGateTest {
 
     @Test
     fun `hides splash when authenticated and fade is done`() {
-        assertFalse(shouldShowSplash(SessionState.Authenticated, splashFadeDone = true))
+        assertFalse(shouldShowSplash(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0), splashFadeDone = true))
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
@@ -1,0 +1,51 @@
+package org.weekendware.basil.presentation.session
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+/**
+ * QA test suite for [authenticatedDestination] — the pure routing decision
+ * that gates the 30-day email-verification soft-block.
+ */
+class SessionStateRoutingTest {
+
+    @Test
+    fun `verified user routes to Normal regardless of account age`() {
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0)),
+        )
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 500)),
+        )
+    }
+
+    @Test
+    fun `unverified user within the grace period routes to Normal`() {
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 0)),
+        )
+        assertEquals(
+            AuthenticatedDestination.Normal,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 29)),
+        )
+    }
+
+    @Test
+    fun `unverified user at exactly the 30-day boundary routes to the verification wall`() {
+        assertEquals(
+            AuthenticatedDestination.VerificationWall,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 30)),
+        )
+    }
+
+    @Test
+    fun `unverified user well past 30 days routes to the verification wall`() {
+        assertEquals(
+            AuthenticatedDestination.VerificationWall,
+            authenticatedDestination(SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 100)),
+        )
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/VerificationWallViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/VerificationWallViewModelTest.kt
@@ -1,0 +1,92 @@
+package org.weekendware.basil.presentation.auth
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class VerificationWallViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state shows the signed-in user's email and allows resend`() {
+        repo.setSignedIn(true)
+        val viewModel = VerificationWallViewModel(repo)
+        val state = viewModel.state.value
+        assertEquals("fake@example.com", state.email) // FakeAuthRepository's fixed signed-in email
+        assertTrue(state.canResend)
+        assertFalse(state.isLoading)
+    }
+
+    @Test
+    fun `onResend calls the repository and immediately starts the cooldown`() = runTest {
+        repo.setSignedIn(true)
+        val viewModel = VerificationWallViewModel(repo)
+
+        viewModel.onResend()
+
+        assertEquals(1, repo.resendVerificationCallCount)
+        assertFalse(viewModel.state.value.canResend)
+    }
+
+    @Test
+    fun `cooldown clears after 60 seconds of virtual time`() = runTest {
+        repo.setSignedIn(true)
+        val viewModel = VerificationWallViewModel(repo)
+
+        viewModel.onResend()
+        assertFalse(viewModel.state.value.canResend)
+
+        advanceTimeBy(60_001)
+
+        assertTrue(viewModel.state.value.canResend)
+    }
+
+    @Test
+    fun `onResend is a no-op while the cooldown is active`() = runTest {
+        repo.setSignedIn(true)
+        val viewModel = VerificationWallViewModel(repo)
+
+        // Two rapid calls in the same virtual-time instant — the second should
+        // see canResend already false from the first call's synchronous update.
+        viewModel.onResend()
+        val callsAfterFirst = repo.resendVerificationCallCount
+        viewModel.onResend()
+
+        assertEquals(callsAfterFirst, repo.resendVerificationCallCount)
+    }
+
+    @Test
+    fun `onSignOut calls the repository`() = runTest {
+        repo.setSignedIn(true)
+        val viewModel = VerificationWallViewModel(repo)
+
+        viewModel.onSignOut()
+
+        assertFalse(repo.isSignedIn())
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/chat/ChatViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/chat/ChatViewModelTest.kt
@@ -12,6 +12,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 import org.weekendware.basil.data.repository.ChatRepository
+import org.weekendware.basil.data.repository.FakeAuthRepository
 import org.weekendware.basil.domain.usecase.SendMessageUseCase
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -23,8 +24,9 @@ class ChatViewModelTest {
 
     private val chatRepository = mock<ChatRepository>()
     private val sendMessage = SendMessageUseCase(chatRepository)
+    private val authRepository = FakeAuthRepository().apply { setSignedIn(true) }
 
-    private fun makeVm() = ChatViewModel(sendMessage, coroutineScope = null)
+    private fun makeVm() = ChatViewModel(sendMessage, authRepository, coroutineScope = null)
 
     // ── initial state ─────────────────────────────────────────
 
@@ -81,7 +83,7 @@ class ChatViewModelTest {
 
     @Test
     fun `sendMessage does nothing when input is blank`() = runTest {
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("   ")
 
         vm.sendMessage()
@@ -93,7 +95,7 @@ class ChatViewModelTest {
 
     @Test
     fun `sendMessage does nothing when input is empty`() = runTest {
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
 
         vm.sendMessage()
         advanceUntilIdle()
@@ -106,7 +108,7 @@ class ChatViewModelTest {
     @Test
     fun `sendMessage adds user message to the conversation`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf())
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("How do I adjust my basal rate?")
 
         vm.sendMessage()
@@ -119,7 +121,7 @@ class ChatViewModelTest {
     @Test
     fun `sendMessage clears the input field after sending`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf())
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("My question")
 
         vm.sendMessage()
@@ -133,7 +135,7 @@ class ChatViewModelTest {
         // Use a flow that never completes so we can inspect mid-stream state.
         // We just need to verify the assistant message is added.
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf("Hi"))
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Hello")
 
         vm.sendMessage()
@@ -148,7 +150,7 @@ class ChatViewModelTest {
         whenever(chatRepository.streamChat(any())).thenReturn(
             flowOf("Hello", ", ", "how", " can", " I", " help?")
         )
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Hi")
 
         vm.sendMessage()
@@ -162,7 +164,7 @@ class ChatViewModelTest {
     @Test
     fun `sendMessage marks isStreaming false on assistant message after flow completes`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf("Done"))
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Test")
 
         vm.sendMessage()
@@ -175,7 +177,7 @@ class ChatViewModelTest {
     @Test
     fun `sendMessage sets isLoading false after stream completes`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf("Hi"))
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Hello")
 
         vm.sendMessage()
@@ -187,7 +189,7 @@ class ChatViewModelTest {
     @Test
     fun `conversation history is passed to the repository on second send`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf("Sure!"))
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
 
         vm.onInputChange("First question")
         vm.sendMessage()
@@ -209,7 +211,7 @@ class ChatViewModelTest {
         whenever(chatRepository.streamChat(any())).thenReturn(
             flow { throw RuntimeException("Network error") }
         )
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Will this fail?")
 
         vm.sendMessage()
@@ -223,7 +225,7 @@ class ChatViewModelTest {
         whenever(chatRepository.streamChat(any())).thenReturn(
             flow { throw RuntimeException("Network error") }
         )
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Question")
 
         vm.sendMessage()
@@ -240,7 +242,7 @@ class ChatViewModelTest {
                 throw RuntimeException("Stream cut off")
             }
         )
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Question")
 
         vm.sendMessage()
@@ -267,7 +269,7 @@ class ChatViewModelTest {
     @Test
     fun `setGreeting does nothing when messages already exist`() = runTest {
         whenever(chatRepository.streamChat(any())).thenReturn(flowOf("Hi there"))
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Hello")
         vm.sendMessage()
         advanceUntilIdle()
@@ -286,7 +288,7 @@ class ChatViewModelTest {
         whenever(chatRepository.streamChat(any())).thenReturn(
             flow { throw RuntimeException("Network error") }
         )
-        val vm = ChatViewModel(sendMessage, coroutineScope = this)
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
         vm.onInputChange("Question")
         vm.sendMessage()
         advanceUntilIdle()
@@ -295,5 +297,59 @@ class ChatViewModelTest {
         vm.clearError()
 
         assertNull(vm.state.value.error)
+    }
+
+    // ── verification banner ──────────────────────────────────
+
+    @Test
+    fun `banner is hidden on init when the user is verified`() {
+        authRepository.emailVerified = true
+
+        val vm = makeVm()
+
+        assertFalse(vm.state.value.showVerificationBanner)
+    }
+
+    @Test
+    fun `banner is shown on init when the user is unverified`() {
+        authRepository.emailVerified = false
+
+        val vm = makeVm()
+
+        assertTrue(vm.state.value.showVerificationBanner)
+    }
+
+    @Test
+    fun `onDismissVerificationBanner hides the banner for the rest of the session`() {
+        authRepository.emailVerified = false
+        val vm = makeVm()
+        assertTrue(vm.state.value.showVerificationBanner)
+
+        vm.onDismissVerificationBanner()
+
+        assertFalse(vm.state.value.showVerificationBanner)
+    }
+
+    @Test
+    fun `onResendVerification calls the repository and clears isResendingVerification on completion`() = runTest {
+        authRepository.emailVerified = false
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
+
+        vm.onResendVerification()
+        advanceUntilIdle()
+
+        assertEquals(1, authRepository.resendVerificationCallCount)
+        assertFalse(vm.state.value.isResendingVerification)
+    }
+
+    @Test
+    fun `onResendVerification does not dismiss the banner`() = runTest {
+        authRepository.emailVerified = false
+        val vm = ChatViewModel(sendMessage, authRepository, coroutineScope = this)
+
+        vm.onResendVerification()
+        advanceUntilIdle()
+
+        assertTrue(vm.state.value.showVerificationBanner)
     }
 }

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
@@ -39,7 +39,7 @@ class SessionViewModelTest {
     @Test
     fun `state becomes Authenticated when session flow emits true`() = runTest {
         repo.setSignedIn(true)
-        assertEquals(SessionState.Authenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Authenticated)
     }
 
     @Test
@@ -52,8 +52,32 @@ class SessionViewModelTest {
     @Test
     fun `state reflects sign-out after sign-in`() = runTest {
         repo.setSignedIn(true)
-        assertEquals(SessionState.Authenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Authenticated)
         repo.signOut()
         assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+    }
+
+    @Test
+    fun `Authenticated carries the repository's verification status`() = runTest {
+        repo.emailVerified = true
+        repo.daysSinceSignupValue = 5
+        repo.setSignedIn(true)
+
+        assertEquals(
+            SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 5),
+            viewModel.state.value,
+        )
+    }
+
+    @Test
+    fun `Authenticated reflects an unverified user past the 30-day threshold`() = runTest {
+        repo.emailVerified = false
+        repo.daysSinceSignupValue = 31
+        repo.setSignedIn(true)
+
+        assertEquals(
+            SessionState.Authenticated(isEmailVerified = false, daysSinceSignup = 31),
+            viewModel.state.value,
+        )
     }
 }


### PR DESCRIPTION
## Summary
Depends on #57 (SessionState/routing), #62 (latest AuthScreen), #55, #53, #56 — merged in locally. Matches AUTH-08 (dismissible chat banner) and AUTH-09 (full-screen 30-day wall) in the mockup.

## What's here
- **\`VerificationWallScreen\`** — real content at last. It's been a blank \`Box\` placeholder since #57 introduced the routing. Lock icon, heading, body, email, "Resend verification email", "Sign out and use a different account". Fully green.
- **\`ChatViewModel\`** now takes \`AuthRepository\` as a constructor dependency, checked once on init. \`ChatState\` gains \`showVerificationBanner\`/\`isResendingVerification\`. Only checks \`isEmailVerified()\`, not days-since-signup — this screen is only ever reachable for a verified user or one still within the grace period, since \`authenticatedDestination()\` (#57) already routes past-30-days users to the wall instead.
- **\`VerificationBanner\`** composable on \`ChatScreen\`, dismissible for the session, with a resend action.

## Two real bugs caught and fixed along the way
1. **Wiring bug in #62**: \`ResetPasswordViewModel\` and \`NewPasswordViewModel\` were never registered in Koin — both screens would have crashed at runtime with "no definition found" the instant either was opened. Caught while wiring \`VerificationWallViewModel\` alongside them; fixed in this branch.
2. **My own test bug**: assumed \`runTest\` auto-advances virtual time mid-test for the 60s resend cooldown — it only auto-advances at the test's end, not mid-assertion. Split into two tests: cooldown starts immediately (no time needed), cooldown clears after \`advanceTimeBy(60_001)\`.

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\`, \`:composeApp:compileDevDebugKotlinAndroid\`, \`:composeApp:compileKotlinDesktop\` — all clean
- [x] \`VerificationWallViewModelTest\` — 5/5 green
- [x] \`ChatViewModelTest\` — 26/26 green (21 pre-existing, all 15 call sites updated for the new constructor param, + 5 new banner tests)
- [x] No regressions elsewhere
- [ ] Manual: verify against the mockup visually (not verifiable from this environment)
- [ ] Copywriter pass on new strings