### PR TITLE
Add save-progress screen: sign-up via Apple/Google/email (AUTH-12/12b)

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -49,6 +49,14 @@
     <string name="auth_verify_banner_text">Please verify your email to keep your account safe.</string>
     <string name="auth_verify_banner_resend">Resend</string>
 
+    <!-- ── Save your progress (end of onboarding) ────────────── -->
+    <string name="save_progress_title">Save your progress</string>
+    <string name="save_progress_basil_message">I want to make sure I remember all of this. Let\'s save your progress so we can pick up right here.</string>
+    <string name="save_progress_continue_with_email">Continue with email</string>
+    <string name="save_progress_maybe_later">Maybe later</string>
+    <string name="save_progress_create_account_title">Create your account</string>
+    <string name="save_progress_create_account">Create account</string>
+
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>
     <string name="nav_chat">Chat</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -28,6 +28,7 @@ import org.weekendware.basil.presentation.auth.ResetPasswordViewModel
 import org.weekendware.basil.presentation.auth.VerificationWallViewModel
 import org.weekendware.basil.presentation.chat.ChatViewModel
 import org.weekendware.basil.presentation.onboarding.OnboardingViewModel
+import org.weekendware.basil.presentation.onboarding.SaveProgressViewModel
 import org.weekendware.basil.presentation.profile.ProfileViewModel
 import org.weekendware.basil.presentation.session.SessionViewModel
 import org.weekendware.basil.presentation.settings.SettingsViewModel
@@ -72,6 +73,7 @@ val sharedModule = module {
     viewModel { NewPasswordViewModel(get()) }
     viewModel { VerificationWallViewModel(get()) }
     viewModel { OnboardingViewModel(get(), get(), get(), get()) }
+    viewModel { SaveProgressViewModel(get()) }
     viewModel { ProfileViewModel(get(), get(), get()) }
     viewModel { ChatViewModel(get(), get()) }
     viewModel { SettingsViewModel() }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressScreen.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressScreen.kt
@@ -1,0 +1,449 @@
+package org.weekendware.basil.presentation.onboarding
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.auth_continue_with_apple
+import basil.composeapp.generated.resources.auth_continue_with_google
+import basil.composeapp.generated.resources.auth_field_email
+import basil.composeapp.generated.resources.auth_field_password
+import basil.composeapp.generated.resources.auth_or
+import basil.composeapp.generated.resources.cd_back
+import basil.composeapp.generated.resources.cd_hide_password
+import basil.composeapp.generated.resources.cd_show_password
+import basil.composeapp.generated.resources.save_progress_basil_message
+import basil.composeapp.generated.resources.save_progress_continue_with_email
+import basil.composeapp.generated.resources.save_progress_create_account
+import basil.composeapp.generated.resources.save_progress_create_account_title
+import basil.composeapp.generated.resources.save_progress_maybe_later
+import basil.composeapp.generated.resources.save_progress_title
+import org.jetbrains.compose.resources.stringResource
+import org.jetbrains.compose.ui.tooling.preview.Preview
+import org.koin.compose.viewmodel.koinViewModel
+import org.weekendware.basil.presentation.auth.PasswordRequirement
+import org.weekendware.basil.presentation.auth.PasswordStrength
+import org.weekendware.basil.presentation.theme.BasilPalette
+import org.weekendware.basil.presentation.theme.BasilTheme
+import org.weekendware.basil.presentation.theme.BasilTokens
+import org.weekendware.basil.presentation.theme.backgroundBrush
+import org.weekendware.basil.presentation.theme.basilColors
+
+/**
+ * "Save your progress" — shown at the end of onboarding to create an
+ * account (AUTH-12 choose-method, AUTH-12b email/password entry).
+ *
+ * Not wired into app routing yet: reaching this screen depends on the
+ * full silent-account-provisioning rearchitecture — [OnboardingScreen]
+ * currently only renders inside the authenticated app shell, not before
+ * sign-in, so there's no unauthenticated path that reaches onboarding (and
+ * therefore this screen) at all yet. That's a genuine App.kt routing
+ * rearchitecture, not something to bolt on here. This composable is
+ * complete and tested standalone, ready for that wiring once it exists.
+ *
+ * @param onMaybeLater Called when the user dismisses this screen without
+ *   creating an account. Per the TDD, they're routed back here on their
+ *   next launch — not wired to any state here, purely a navigation signal
+ *   for whatever screen hosts this one.
+ */
+@Composable
+fun SaveProgressScreen(onMaybeLater: () -> Unit = {}) {
+    val viewModel = koinViewModel<SaveProgressViewModel>()
+    val state by viewModel.state.collectAsStateWithLifecycle()
+
+    SaveProgressScreenContent(
+        state                      = state,
+        onContinueWithEmail        = viewModel::onContinueWithEmail,
+        onBackToChooseMethod       = viewModel::onBackToChooseMethod,
+        onEmailChange              = viewModel::onEmailChange,
+        onPasswordChange           = viewModel::onPasswordChange,
+        onTogglePasswordVisibility = viewModel::onTogglePasswordVisibility,
+        onGoogleSignUp             = viewModel::onGoogleSignUp,
+        onAppleSignUp              = viewModel::onAppleSignUp,
+        onCreateAccount            = viewModel::onCreateAccount,
+        onMaybeLater               = onMaybeLater,
+    )
+}
+
+@Composable
+fun SaveProgressScreenContent(
+    state:                      SaveProgressUiState,
+    onContinueWithEmail:         () -> Unit,
+    onBackToChooseMethod:        () -> Unit,
+    onEmailChange:               (String) -> Unit,
+    onPasswordChange:            (String) -> Unit,
+    onTogglePasswordVisibility:  () -> Unit,
+    onGoogleSignUp:               () -> Unit,
+    onAppleSignUp:                () -> Unit,
+    onCreateAccount:              () -> Unit,
+    onMaybeLater:                 () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(MaterialTheme.basilColors.backgroundBrush()),
+    ) {
+        // Onboarding conversation strip — Basil's closing message, matching
+        // the mockup's "conversation visible above the sheet" framing.
+        Column(modifier = Modifier.fillMaxWidth().padding(16.dp)) {
+            Text(
+                text  = "basil",
+                style = MaterialTheme.typography.labelSmall,
+                color = BasilPalette.AuthPlaceholderText,
+            )
+            Spacer(Modifier.height(3.dp))
+            Box(
+                modifier = Modifier
+                    .clip(RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 16.dp, bottomEnd = 4.dp))
+                    .background(Color.White)
+                    .border(1.dp, BasilPalette.AuthGoogleBorder, RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp, bottomStart = 16.dp, bottomEnd = 4.dp))
+                    .padding(horizontal = 14.dp, vertical = 12.dp),
+            ) {
+                Text(
+                    text  = stringResource(Res.string.save_progress_basil_message),
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = BasilPalette.AuthNearBlack,
+                )
+            }
+        }
+
+        Spacer(Modifier.weight(1f))
+
+        // Card
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .clip(RoundedCornerShape(topStart = 20.dp, topEnd = 20.dp))
+                .background(Color.White)
+                .padding(horizontal = 20.dp)
+                .padding(top = 20.dp, bottom = 32.dp)
+                .verticalScroll(rememberScrollState()),
+        ) {
+            when (state.step) {
+                SaveProgressStep.ChooseMethod -> ChooseMethodContent(
+                    onGoogleSignUp      = onGoogleSignUp,
+                    onAppleSignUp       = onAppleSignUp,
+                    onContinueWithEmail = onContinueWithEmail,
+                    onMaybeLater        = onMaybeLater,
+                )
+                SaveProgressStep.EmailEntry -> EmailEntryContent(
+                    state                      = state,
+                    onEmailChange              = onEmailChange,
+                    onPasswordChange           = onPasswordChange,
+                    onTogglePasswordVisibility = onTogglePasswordVisibility,
+                    onCreateAccount            = onCreateAccount,
+                    onBack                     = onBackToChooseMethod,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun ChooseMethodContent(
+    onGoogleSignUp:      () -> Unit,
+    onAppleSignUp:        () -> Unit,
+    onContinueWithEmail: () -> Unit,
+    onMaybeLater:        () -> Unit,
+) {
+    Text(
+        text  = stringResource(Res.string.save_progress_title),
+        style = MaterialTheme.typography.headlineSmall,
+        color = BasilPalette.AuthNearBlack,
+    )
+    Spacer(Modifier.height(16.dp))
+    OutlinedButton(
+        onClick  = onAppleSignUp,
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        border   = BorderStroke(0.dp, Color.Transparent),
+        colors   = ButtonDefaults.outlinedButtonColors(containerColor = BasilPalette.Black, contentColor = Color.White),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+    ) {
+        Text(text = stringResource(Res.string.auth_continue_with_apple), style = MaterialTheme.typography.labelLarge)
+    }
+    Spacer(Modifier.height(10.dp))
+    OutlinedButton(
+        onClick  = onGoogleSignUp,
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        border   = BorderStroke(1.5.dp, BasilPalette.AuthGoogleBorder),
+        colors   = ButtonDefaults.outlinedButtonColors(containerColor = Color.White, contentColor = BasilPalette.AuthNearBlack),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+    ) {
+        Text(text = stringResource(Res.string.auth_continue_with_google), style = MaterialTheme.typography.labelLarge, fontWeight = FontWeight.Medium)
+    }
+    Spacer(Modifier.height(14.dp))
+    Row(verticalAlignment = Alignment.CenterVertically) {
+        HorizontalDivider(modifier = Modifier.weight(1f), color = BasilPalette.AuthFieldBorder.copy(alpha = 0.3f))
+        Text(
+            text     = stringResource(Res.string.auth_or),
+            style    = MaterialTheme.typography.bodyMedium,
+            color    = BasilPalette.AuthFieldText,
+            modifier = Modifier.padding(horizontal = 12.dp),
+        )
+        HorizontalDivider(modifier = Modifier.weight(1f), color = BasilPalette.AuthFieldBorder.copy(alpha = 0.3f))
+    }
+    Spacer(Modifier.height(8.dp))
+    OutlinedButton(
+        onClick  = onContinueWithEmail,
+        shape    = RoundedCornerShape(50),
+        border   = BorderStroke(1.5.dp, BasilPalette.Sage600),
+        colors   = ButtonDefaults.outlinedButtonColors(containerColor = Color.Transparent, contentColor = BasilPalette.Sage600),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+    ) {
+        Text(text = stringResource(Res.string.save_progress_continue_with_email), style = MaterialTheme.typography.labelLarge)
+    }
+    Spacer(Modifier.height(12.dp))
+    TextButton(onClick = onMaybeLater, modifier = Modifier.fillMaxWidth()) {
+        Text(
+            text  = stringResource(Res.string.save_progress_maybe_later),
+            style = MaterialTheme.typography.bodyMedium,
+            color = BasilPalette.AuthPlaceholderText,
+        )
+    }
+}
+
+@Composable
+private fun EmailEntryContent(
+    state:                      SaveProgressUiState,
+    onEmailChange:               (String) -> Unit,
+    onPasswordChange:            (String) -> Unit,
+    onTogglePasswordVisibility:  () -> Unit,
+    onCreateAccount:              () -> Unit,
+    onBack:                       () -> Unit,
+) {
+    Text(
+        text  = stringResource(Res.string.save_progress_create_account_title),
+        style = MaterialTheme.typography.titleLarge,
+        color = BasilPalette.AuthNearBlack,
+    )
+    Spacer(Modifier.height(20.dp))
+    Text(
+        text          = stringResource(Res.string.auth_field_email).uppercase(),
+        style         = MaterialTheme.typography.labelSmall,
+        color         = BasilPalette.AuthFieldText,
+        fontWeight    = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.height(6.dp))
+    OutlinedTextField(
+        value           = state.email,
+        onValueChange   = onEmailChange,
+        singleLine      = true,
+        keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Email, imeAction = ImeAction.Next),
+        colors          = OutlinedTextFieldDefaults.colors(
+            focusedContainerColor   = BasilPalette.Cream,
+            unfocusedContainerColor = BasilPalette.Cream,
+            focusedBorderColor      = BasilPalette.Sage600,
+            unfocusedBorderColor    = BasilPalette.AuthFieldBorder,
+            cursorColor             = BasilPalette.Sage600,
+        ),
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.AuthFieldHeight),
+    )
+    Spacer(Modifier.height(14.dp))
+    Text(
+        text          = stringResource(Res.string.auth_field_password).uppercase(),
+        style         = MaterialTheme.typography.labelSmall,
+        color         = BasilPalette.AuthFieldText,
+        fontWeight    = FontWeight.SemiBold,
+    )
+    Spacer(Modifier.height(6.dp))
+    OutlinedTextField(
+        value                = state.password,
+        onValueChange        = onPasswordChange,
+        singleLine           = true,
+        visualTransformation = if (state.isPasswordVisible) VisualTransformation.None else PasswordVisualTransformation(),
+        keyboardOptions      = KeyboardOptions(keyboardType = KeyboardType.Password, imeAction = ImeAction.Done),
+        keyboardActions      = KeyboardActions(onDone = { onCreateAccount() }),
+        trailingIcon = {
+            IconButton(onClick = onTogglePasswordVisibility) {
+                Icon(
+                    imageVector        = if (state.isPasswordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                    contentDescription = stringResource(if (state.isPasswordVisible) Res.string.cd_hide_password else Res.string.cd_show_password),
+                    tint               = BasilPalette.AuthFieldText,
+                )
+            }
+        },
+        colors = OutlinedTextFieldDefaults.colors(
+            focusedContainerColor   = BasilPalette.Cream,
+            unfocusedContainerColor = BasilPalette.Cream,
+            focusedBorderColor      = if (state.passwordStrength == PasswordStrength.Strong) BasilPalette.AuthStrengthGreen else BasilPalette.Sage600,
+            unfocusedBorderColor    = if (state.passwordStrength == PasswordStrength.Strong) BasilPalette.AuthStrengthGreen else BasilPalette.AuthFieldBorder,
+            cursorColor             = BasilPalette.Sage600,
+        ),
+        shape    = RoundedCornerShape(BasilTokens.AuthFieldCorner),
+        modifier = Modifier.fillMaxWidth().height(BasilTokens.AuthFieldHeight),
+    )
+    PasswordStrengthIndicator(strength = state.passwordStrength, requirements = state.passwordRequirements)
+    state.error?.let { errorRes ->
+        Spacer(Modifier.height(8.dp))
+        Text(text = stringResource(errorRes), style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+    }
+    Spacer(Modifier.height(8.dp))
+    if (state.isLoading) {
+        Box(Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            CircularProgressIndicator(color = BasilPalette.Sage600)
+        }
+    } else {
+        Button(
+            onClick  = onCreateAccount,
+            enabled  = state.canCreateAccount,
+            shape    = RoundedCornerShape(50),
+            colors   = ButtonDefaults.buttonColors(
+                containerColor        = BasilPalette.Sage600,
+                contentColor          = Color.White,
+                disabledContainerColor = BasilPalette.AuthButtonMuted,
+                disabledContentColor   = Color.White,
+            ),
+            modifier = Modifier.fillMaxWidth().height(BasilTokens.ButtonHeight),
+        ) {
+            Text(text = stringResource(Res.string.save_progress_create_account), style = MaterialTheme.typography.labelLarge)
+        }
+    }
+    Spacer(Modifier.height(12.dp))
+    Box(modifier = Modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+        IconButton(onClick = onBack) {
+            Icon(
+                imageVector        = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = stringResource(Res.string.cd_back),
+                tint               = BasilPalette.AuthFieldText,
+                modifier           = Modifier.size(16.dp),
+            )
+        }
+    }
+}
+
+/** Same segmented bar + requirement checklist as [org.weekendware.basil.presentation.auth.NewPasswordScreen]. */
+@Composable
+private fun PasswordStrengthIndicator(strength: PasswordStrength, requirements: List<PasswordRequirement>) {
+    if (strength == PasswordStrength.None) return
+
+    val (filledCount, color, label) = when (strength) {
+        PasswordStrength.Weak   -> Triple(1, BasilPalette.Error, "Weak")
+        PasswordStrength.Medium -> Triple(2, BasilPalette.AuthStrengthAmber, "Medium")
+        PasswordStrength.Strong -> Triple(3, BasilPalette.AuthStrengthGreen, "Strong")
+        PasswordStrength.None   -> Triple(0, BasilPalette.AuthFieldBorder, "")
+    }
+
+    Column(modifier = Modifier.padding(top = 10.dp, bottom = 10.dp)) {
+        Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+            repeat(3) { index ->
+                Box(
+                    modifier = Modifier
+                        .weight(1f)
+                        .height(4.dp)
+                        .padding(end = if (index < 2) 3.dp else 0.dp)
+                        .clip(RoundedCornerShape(2.dp))
+                        .background(if (index < filledCount) color else BasilPalette.AuthGoogleBorder),
+                )
+            }
+            Spacer(Modifier.width(8.dp))
+            Text(text = label, style = MaterialTheme.typography.labelSmall, color = color, fontWeight = FontWeight.SemiBold)
+        }
+        Spacer(Modifier.height(8.dp))
+        requirements.forEach { requirement ->
+            Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.padding(vertical = 2.dp)) {
+                Box(
+                    modifier = if (requirement.met) {
+                        Modifier.size(14.dp).clip(CircleShape).background(BasilPalette.Sage600)
+                    } else {
+                        Modifier.size(14.dp).clip(CircleShape).border(1.5.dp, BasilPalette.AuthFieldBorder, CircleShape)
+                    },
+                    contentAlignment = Alignment.Center,
+                ) {
+                    if (requirement.met) {
+                        Text(text = "✓", style = MaterialTheme.typography.labelSmall, color = Color.White)
+                    }
+                }
+                Spacer(Modifier.width(7.dp))
+                Text(text = stringResource(requirement.label), style = MaterialTheme.typography.labelSmall, color = BasilPalette.AuthFieldText)
+            }
+        }
+    }
+}
+
+// ─────────────────────────────────────────────────────────────
+// Previews
+// ─────────────────────────────────────────────────────────────
+
+@Preview
+@Composable
+internal fun SaveProgressChooseMethodPreview() {
+    BasilTheme {
+        SaveProgressScreenContent(
+            state                      = SaveProgressUiState(),
+            onContinueWithEmail        = {},
+            onBackToChooseMethod       = {},
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onGoogleSignUp             = {},
+            onAppleSignUp              = {},
+            onCreateAccount            = {},
+            onMaybeLater               = {},
+        )
+    }
+}
+
+@Preview
+@Composable
+internal fun SaveProgressEmailEntryPreview() {
+    BasilTheme {
+        SaveProgressScreenContent(
+            state = SaveProgressUiState(step = SaveProgressStep.EmailEntry, email = "john@example.com"),
+            onContinueWithEmail        = {},
+            onBackToChooseMethod       = {},
+            onEmailChange              = {},
+            onPasswordChange           = {},
+            onTogglePasswordVisibility = {},
+            onGoogleSignUp             = {},
+            onAppleSignUp              = {},
+            onCreateAccount            = {},
+            onMaybeLater               = {},
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModel.kt
@@ -1,0 +1,99 @@
+package org.weekendware.basil.presentation.onboarding
+
+import androidx.compose.runtime.Immutable
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.StringResource
+import org.weekendware.basil.data.repository.AuthRepository
+import org.weekendware.basil.presentation.auth.PasswordRequirement
+import org.weekendware.basil.presentation.auth.PasswordStrength
+import org.weekendware.basil.presentation.auth.PasswordStrengthValidator
+
+/** Which step of the "Save your progress" flow is showing. */
+enum class SaveProgressStep { ChooseMethod, EmailEntry }
+
+/**
+ * State for [SaveProgressScreen] — shown at the end of onboarding to create
+ * an account (AUTH-12 choose-method, AUTH-12b email/password entry).
+ *
+ * @property isPasswordVisible Shared by password and confirm-password
+ *   fields — see [org.weekendware.basil.presentation.auth.NewPasswordUiState]
+ *   for the same rule and its rationale.
+ */
+@Immutable
+data class SaveProgressUiState(
+    val step: SaveProgressStep = SaveProgressStep.ChooseMethod,
+    val email: String = "",
+    val password: String = "",
+    val isPasswordVisible: Boolean = false,
+    val passwordStrength: PasswordStrength = PasswordStrength.None,
+    val passwordRequirements: List<PasswordRequirement> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: StringResource? = null,
+) {
+    val canCreateAccount: Boolean get() = passwordStrength == PasswordStrength.Strong && email.isNotBlank() && !isLoading
+}
+
+/**
+ * ViewModel for [SaveProgressScreen]. Only handles account creation itself
+ * — syncing the already-collected local onboarding answers to Supabase
+ * once the account exists is
+ * [org.weekendware.basil.presentation.onboarding.OnboardingViewModel]'s job,
+ * not this screen's, matching the TDD's `syncLocalToSupabase(userId)` call
+ * "once, after successful sign-up."
+ */
+class SaveProgressViewModel(
+    private val authRepository: AuthRepository
+) : ViewModel() {
+
+    private val _state = MutableStateFlow(SaveProgressUiState())
+    val state: StateFlow<SaveProgressUiState> = _state
+
+    fun onContinueWithEmail() = _state.update { it.copy(step = SaveProgressStep.EmailEntry) }
+    fun onBackToChooseMethod() = _state.update { it.copy(step = SaveProgressStep.ChooseMethod, error = null) }
+
+    fun onEmailChange(value: String) = _state.update { it.copy(email = value, error = null) }
+    fun onTogglePasswordVisibility() = _state.update { it.copy(isPasswordVisible = !it.isPasswordVisible) }
+
+    fun onPasswordChange(value: String) {
+        val (strength, requirements) = PasswordStrengthValidator.validate(value)
+        _state.update {
+            it.copy(password = value, passwordStrength = strength, passwordRequirements = requirements, error = null)
+        }
+    }
+
+    fun onGoogleSignUp() = signUpWithProvider(authRepository::signInWithGoogle)
+    fun onAppleSignUp() = signUpWithProvider(authRepository::signInWithApple)
+
+    fun onCreateAccount() {
+        val current = _state.value
+        if (!current.canCreateAccount) return
+
+        _state.update { it.copy(isLoading = true, error = null) }
+
+        viewModelScope.launch {
+            val result = authRepository.signUp(current.email, current.password)
+            result.fold(
+                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
+            )
+        }
+    }
+
+    private fun signUpWithProvider(provider: suspend () -> Result<Unit>) {
+        _state.update { it.copy(isLoading = true, error = null) }
+        viewModelScope.launch {
+            val result = provider()
+            result.fold(
+                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
+            )
+        }
+    }
+}

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModelTest.kt
@@ -1,0 +1,136 @@
+package org.weekendware.basil.presentation.onboarding
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.error_auth_failed
+import org.weekendware.basil.data.repository.FakeAuthRepository
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * QA test suite for [SaveProgressViewModel]. Every case touching
+ * [SaveProgressViewModel.onPasswordChange] is expected to fail with
+ * `NotImplementedError` until Backend implements
+ * [org.weekendware.basil.presentation.auth.PasswordStrengthValidator] —
+ * same situation as [org.weekendware.basil.presentation.auth.NewPasswordViewModelTest].
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+class SaveProgressViewModelTest {
+
+    private val dispatcher = UnconfinedTestDispatcher()
+    private lateinit var repo: FakeAuthRepository
+    private lateinit var viewModel: SaveProgressViewModel
+
+    @BeforeTest
+    fun setup() {
+        Dispatchers.setMain(dispatcher)
+        repo = FakeAuthRepository()
+        viewModel = SaveProgressViewModel(repo)
+    }
+
+    @AfterTest
+    fun teardown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `initial state is the choose-method step, nothing entered`() {
+        val state = viewModel.state.value
+        assertEquals(SaveProgressStep.ChooseMethod, state.step)
+        assertEquals("", state.email)
+        assertEquals("", state.password)
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `onContinueWithEmail advances to the email-entry step`() {
+        viewModel.onContinueWithEmail()
+        assertEquals(SaveProgressStep.EmailEntry, viewModel.state.value.step)
+    }
+
+    @Test
+    fun `onBackToChooseMethod returns to the choose-method step`() {
+        viewModel.onContinueWithEmail()
+        viewModel.onBackToChooseMethod()
+        assertEquals(SaveProgressStep.ChooseMethod, viewModel.state.value.step)
+    }
+
+    @Test
+    fun `onTogglePasswordVisibility flips the flag`() {
+        assertFalse(viewModel.state.value.isPasswordVisible)
+        viewModel.onTogglePasswordVisibility()
+        assertTrue(viewModel.state.value.isPasswordVisible)
+    }
+
+    @Test
+    fun `canCreateAccount is false until password strength is Strong`() {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("weak")
+        assertFalse(viewModel.state.value.canCreateAccount)
+    }
+
+    @Test
+    fun `canCreateAccount is true with a strong password and a non-blank email`() {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("Abcdefg1!")
+        assertTrue(viewModel.state.value.canCreateAccount)
+    }
+
+    @Test
+    fun `onCreateAccount does nothing when canCreateAccount is false`() = runTest {
+        viewModel.onCreateAccount()
+        assertFalse(repo.isSignedIn())
+    }
+
+    @Test
+    fun `successful onCreateAccount signs up and clears loading`() = runTest {
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onCreateAccount()
+
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `failed onCreateAccount surfaces an error`() = runTest {
+        repo.signUpResult = Result.failure(Exception("email already registered"))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("Abcdefg1!")
+        viewModel.onCreateAccount()
+
+        assertEquals(Res.string.error_auth_failed, viewModel.state.value.error)
+        assertFalse(viewModel.state.value.isLoading)
+    }
+
+    @Test
+    fun `successful onGoogleSignUp signs in and clears loading`() = runTest {
+        viewModel.onGoogleSignUp()
+        val state = viewModel.state.value
+        assertFalse(state.isLoading)
+        assertNull(state.error)
+        assertTrue(repo.isSignedIn())
+    }
+
+    @Test
+    fun `failed onAppleSignUp surfaces an error`() = runTest {
+        repo.appleSignInResult = Result.failure(Exception("cancelled"))
+        viewModel.onAppleSignUp()
+        val state = viewModel.state.value
+        assertEquals(Res.string.error_auth_failed, state.error)
+        assertFalse(state.isLoading)
+    }
+}


### PR DESCRIPTION
## Summary
Depends on #63, #62, #57, #55, #53, #56 — merged in locally. Matches AUTH-12 (choose method) and AUTH-12b (email/password creation, all three strength states) in the mockup.

## What's here
- **\`SaveProgressViewModel\`/\`SaveProgressScreen\`** — choose-method step (Apple, Google, "Continue with email", "Maybe later") and email/password creation step, reusing the same live strength-bar pattern as \`NewPasswordScreen\` (#62).
- Reused the existing \`MaterialTheme.basilColors.backgroundBrush()\` token for the onboarding gradient instead of hardcoding a duplicate — caught this before shipping a second copy of the same gradient values.

## Known gap — flagged, not silently skipped
**Not wired into app routing.** Reaching this screen requires the full silent-account-provisioning rearchitecture from the TDD: today, \`OnboardingScreen\` only renders inside the authenticated app shell (\`AuthenticatedRoot\`), so there's no unauthenticated path that reaches onboarding — and therefore this screen — at all. That's a real \`App.kt\` routing change (moving onboarding pre-auth, guarding \`OnboardingViewModel\`'s Supabase calls appropriately, adding the \`OnboardingCompleteNoAccount\` session-adjacent state), not something to bolt on inside this screen's own PR. Same treatment as \`NewPasswordScreen\` in #62: built and tested standalone, ready for that wiring once it exists. I'd flag this as the single largest remaining piece of real engineering work in the whole feature — it touches currently-shipped, working onboarding code, not just new screens.

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\`, \`:composeApp:compileDevDebugKotlinAndroid\`, \`:composeApp:compileKotlinDesktop\` — all clean
- [x] \`SaveProgressViewModelTest\` — 7/11 green, 4 red as documented (all touch the still-\`TODO()\`'d \`PasswordStrengthValidator\`)
- [x] No regressions elsewhere
- [ ] Manual: verify against the mockup visually (not verifiable from this environment)
- [ ] Copywriter pass on new strings (Basil's closing message is placeholder-quality, not final voice)
- [ ] App.kt routing rearchitecture to actually reach this screen