### PR TITLE
QA: passkey auth prompt contract + test suite

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -42,16 +42,16 @@
 
     <!-- ── Email verification wall / banner ──────────────────── -->
     <string name="auth_verify_wall_title">Verify your email</string>
-    <string name="auth_verify_wall_body">To keep your account secure, we need to confirm your email address.</string>
+    <string name="auth_verify_wall_body">We need to confirm your email to keep your account secure.</string>
     <string name="auth_verify_wall_sent_to">We sent a verification link to</string>
     <string name="auth_resend_verification">Resend verification email</string>
     <string name="auth_sign_out_different_account">Sign out and use a different account</string>
-    <string name="auth_verify_banner_text">Please verify your email to keep your account safe.</string>
+    <string name="auth_verify_banner_text">Verify your email to keep your account safe.</string>
     <string name="auth_verify_banner_resend">Resend</string>
 
     <!-- ── Save your progress (end of onboarding) ────────────── -->
     <string name="save_progress_title">Save your progress</string>
-    <string name="save_progress_basil_message">I want to make sure I remember all of this. Let\'s save your progress so we can pick up right here.</string>
+    <string name="save_progress_basil_message">I don\'t want to lose any of this — let\'s save it, so I\'m here when you come back.</string>
     <string name="save_progress_continue_with_email">Continue with email</string>
     <string name="save_progress_maybe_later">Maybe later</string>
     <string name="save_progress_create_account_title">Create your account</string>
@@ -76,7 +76,7 @@
     <string name="profile_action_edit">Edit</string>
     <string name="profile_action_save">Save</string>
     <string name="profile_action_cancel">Cancel</string>
-    <string name="profile_no_user">No profile data found</string>
+    <string name="profile_no_user">No profile found</string>
     <string name="error_profile_save_failed">Failed to save profile. Please try again.</string>
     <string name="profile_pick_photo">Change photo</string>
     <string name="profile_remove_photo">Remove photo</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -20,7 +20,7 @@
     <string name="auth_forgot_password">Forgot password?</string>
     <string name="auth_use_different_account">Use a different account</string>
     <string name="auth_no_account_title">No account found</string>
-    <string name="auth_no_account_body">Start the conversation to create one. It only takes a minute.</string>
+    <string name="auth_no_account_body">Start a conversation to create one.</string>
     <string name="auth_get_started">Get started</string>
     <string name="auth_try_different_email">Try a different email</string>
     <string name="cd_show_password">Show password</string>
@@ -50,7 +50,7 @@
     <string name="auth_verify_banner_resend">Resend</string>
 
     <!-- ── Save your progress (end of onboarding) ────────────── -->
-    <string name="save_progress_title">Save your progress</string>
+    <string name="save_progress_title">Save your spot</string>
     <string name="save_progress_basil_message">I don\'t want to lose any of this — let\'s save it, so I\'m here when you come back.</string>
     <string name="save_progress_continue_with_email">Continue with email</string>
     <string name="save_progress_maybe_later">Maybe later</string>
@@ -58,10 +58,10 @@
     <string name="save_progress_create_account">Create account</string>
 
     <!-- ── Passkey auth prompt ────────────────────────────────── -->
-    <string name="auth_passkey_scanning">Looking for your face…</string>
-    <string name="auth_passkey_first_failure">Face ID didn\'t recognise you</string>
+    <string name="auth_passkey_scanning">Looking for you…</string>
+    <string name="auth_passkey_first_failure">Didn\'t recognise you.</string>
     <string name="auth_passkey_try_again">Try again</string>
-    <string name="auth_passkey_second_failure">Face ID didn\'t work — sign in another way.</string>
+    <string name="auth_passkey_second_failure">Still no luck — sign in with your email instead.</string>
 
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>
@@ -138,7 +138,7 @@
     <string name="onboarding_retry">Try again</string>
 
     <!-- ── Error messages ──────────────────────────────────── -->
-    <string name="error_auth_failed">Authentication failed</string>
+    <string name="error_auth_failed">Something went wrong. Please try again.</string>
     <string name="error_chat_failed">Something went wrong. Please try again.</string>
     <string name="onboarding_error_network">No connection. Check your signal and try again.</string>
     <string name="onboarding_error_server">Something went wrong on our end. Try again in a moment.</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -57,6 +57,12 @@
     <string name="save_progress_create_account_title">Create your account</string>
     <string name="save_progress_create_account">Create account</string>
 
+    <!-- ── Passkey auth prompt ────────────────────────────────── -->
+    <string name="auth_passkey_scanning">Looking for your face…</string>
+    <string name="auth_passkey_first_failure">Face ID didn\'t recognise you</string>
+    <string name="auth_passkey_try_again">Try again</string>
+    <string name="auth_passkey_second_failure">Face ID didn\'t work — sign in another way.</string>
+
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>
     <string name="nav_chat">Chat</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/AuthViewModel.kt
@@ -18,13 +18,17 @@ enum class AuthMode { SignIn, SignUp }
 /**
  * State for the email-first auth screen.
  *
- * @property mode              Whether the entered email matched a stored one (SignIn) or not (SignUp).
- * @property email             Current value of the email field.
- * @property password          Current value of the password field. Unused while [emailStep] is true.
- * @property emailStep         True while the user is on the email-only step; false once past it.
- * @property isLoading         True while an auth network call is in flight.
- * @property isPasswordVisible True when the password field shows plain text instead of masked dots.
- * @property error             User-facing error string resource, or null when there is none.
+ * @property mode                  Whether the entered email matched a stored one (SignIn) or not (SignUp).
+ * @property email                 Current value of the email field.
+ * @property password              Current value of the password field. Unused while [emailStep] is true.
+ * @property emailStep             True while the user is on the email-only step; false once past it.
+ * @property isLoading             True while an auth network call is in flight.
+ * @property isPasswordVisible     True when the password field shows plain text instead of masked dots.
+ * @property error                 User-facing error string resource, or null when there is none.
+ * @property isPasskeyAvailable    True if this device has an enrolled passkey. While true (and
+ *   [biometricAttemptCount] is under 2) the biometric prompt replaces the email step entirely.
+ * @property biometricAttemptCount 0 = auto-triggering/scanning, 1 = first failure (retry offered),
+ *   2 = second failure ([isPasskeyAvailable] is set false and the standard form takes over).
  */
 @Immutable
 data class AuthUiState(
@@ -35,9 +39,12 @@ data class AuthUiState(
     val isLoading: Boolean = false,
     val isPasswordVisible: Boolean = false,
     val error: StringResource? = null,
+    val isPasskeyAvailable: Boolean = false,
+    val biometricAttemptCount: Int = 0,
 ) {
     val canContinueEmail: Boolean get() = email.isNotBlank() && !isLoading
     val canSubmit: Boolean get() = password.isNotBlank() && !isLoading
+    val showPasskeyPrompt: Boolean get() = isPasskeyAvailable && biometricAttemptCount < 2
 }
 
 /**
@@ -57,10 +64,34 @@ class AuthViewModel(
     private val authRepository: AuthRepository
 ) : ViewModel() {
 
-    private val _state = MutableStateFlow(AuthUiState())
+    private val _state = MutableStateFlow(
+        AuthUiState(isPasskeyAvailable = authRepository.hasPasskeyEnrolled())
+    )
 
     /** The current form state observed by [AuthScreen]. */
     val state: StateFlow<AuthUiState> = _state
+
+    /**
+     * Called from a `LaunchedEffect(Unit)` the instant the biometric prompt
+     * composes — fires automatically, no button tap. Also what "Try again"
+     * calls directly on the first failure. On a second failure, falls
+     * through to the standard form with a contextual error message.
+     *
+     * **Not implemented here.** QA scaffolding only — see
+     * [AuthViewModelTest] for the full contract (attempt-count transitions,
+     * the second-failure fallback message, and the successful-auth case).
+     */
+    fun onPasskeyScreenEntered() {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC18b/19b biometric attempt states")
+    }
+
+    /** "Try again" on the first failure — re-invokes the ceremony directly, same as the auto-trigger. */
+    fun onPasskeyRetry() {
+        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC18b/19b biometric attempt states")
+    }
+
+    /** Escape hatch from the biometric prompt to the standard form, without recording it as a failure. */
+    fun onUseDifferentAccountFromPasskey() = _state.update { it.copy(isPasskeyAvailable = false) }
 
     fun onEmailChange(value: String) = _state.update { it.copy(email = value, error = null) }
     fun onPasswordChange(value: String) = _state.update { it.copy(password = value, error = null) }

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/auth/AuthViewModelTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.auth_passkey_second_failure
 import basil.composeapp.generated.resources.error_auth_failed
 import org.weekendware.basil.data.repository.FakeAuthRepository
 import kotlin.test.AfterTest
@@ -191,5 +192,77 @@ class AuthViewModelTest {
         val state = viewModel.state.value
         assertEquals(Res.string.error_auth_failed, state.error)
         assertFalse(state.isLoading)
+    }
+
+    // ── passkey prompt ────────────────────────────────────────
+    // repo.passkeyEnrolled must be set before constructing the ViewModel —
+    // isPasskeyAvailable is read once, on init, not observed reactively.
+
+    @Test
+    fun `isPasskeyAvailable is false when no passkey is enrolled on this device`() {
+        assertFalse(viewModel.state.value.isPasskeyAvailable)
+        assertFalse(viewModel.state.value.showPasskeyPrompt)
+    }
+
+    @Test
+    fun `isPasskeyAvailable is true and showPasskeyPrompt is true when a passkey is enrolled`() {
+        repo.passkeyEnrolled = true
+        val vm = AuthViewModel(repo)
+        assertTrue(vm.state.value.isPasskeyAvailable)
+        assertTrue(vm.state.value.showPasskeyPrompt)
+    }
+
+    @Test
+    fun `first biometric failure increments the attempt count without dropping to the form`() = runTest {
+        repo.passkeyEnrolled = true
+        repo.signInWithPasskeyResult = Result.failure(Exception("not recognized"))
+        val vm = AuthViewModel(repo)
+
+        vm.onPasskeyScreenEntered()
+
+        val state = vm.state.value
+        assertEquals(1, state.biometricAttemptCount)
+        assertTrue(state.isPasskeyAvailable)
+        assertTrue(state.showPasskeyPrompt)
+        assertNull(state.error)
+    }
+
+    @Test
+    fun `second biometric failure drops to the standard form with a contextual message`() = runTest {
+        repo.passkeyEnrolled = true
+        repo.signInWithPasskeyResult = Result.failure(Exception("not recognized"))
+        val vm = AuthViewModel(repo)
+
+        vm.onPasskeyScreenEntered()
+        vm.onPasskeyRetry()
+
+        val state = vm.state.value
+        assertEquals(2, state.biometricAttemptCount)
+        assertFalse(state.isPasskeyAvailable)
+        assertFalse(state.showPasskeyPrompt)
+        assertEquals(Res.string.auth_passkey_second_failure, state.error)
+    }
+
+    @Test
+    fun `successful biometric auth establishes a session without changing attempt count`() = runTest {
+        repo.passkeyEnrolled = true
+        val vm = AuthViewModel(repo)
+
+        vm.onPasskeyScreenEntered()
+
+        assertTrue(repo.isSignedIn())
+        assertEquals(0, vm.state.value.biometricAttemptCount)
+    }
+
+    @Test
+    fun `onUseDifferentAccountFromPasskey hides the prompt without counting as a failure`() {
+        repo.passkeyEnrolled = true
+        val vm = AuthViewModel(repo)
+
+        vm.onUseDifferentAccountFromPasskey()
+
+        val state = vm.state.value
+        assertFalse(state.isPasskeyAvailable)
+        assertEquals(0, state.biometricAttemptCount)
     }
 }


### PR DESCRIPTION
## Summary
Depends on #64, #63, #62, #61, #55, #53, #56 — merged in locally. QA scaffold for AUTH-04/04b/04c (biometric auto-trigger, first-failure retry, second-failure fallback).

## Process correction
Gavin caught that everything from #61 onward implemented ViewModel logic and wrote its tests in the same commit — exactly what the QA-owns-all-tests rule (added to \`weekendware-team/architect/qa/SKILL.md\` earlier this session) exists to prevent. This branch was mid-flight when the correction landed; reverted \`onPasskeyScreenEntered()\`/\`onPasskeyRetry()\` back to \`TODO()\` stubs before writing the \`PasskeyPrompt\` UI, so this stays a clean QA deliverable — same shape as #53 (\`PasswordStrengthValidator\`) and #60 (\`PasskeyManager\`).

## What's here
- \`AuthUiState\` extended with \`isPasskeyAvailable\` and \`biometricAttemptCount\`
- \`onPasskeyScreenEntered()\`/\`onPasskeyRetry()\` — signature-only \`TODO()\` stubs
- \`onUseDifferentAccountFromPasskey()\` — fully implemented (plain state reset, no repository call, consistent with the already-implemented \`onUseDifferentAccount()\` elsewhere in this file)
- 6 new \`AuthViewModelTest\` cases covering: no-passkey-enrolled, first failure (retry offered, prompt stays up), second failure (drops to form with the contextual message), successful auth, and the escape hatch

## Test plan
- [x] \`:composeApp:linkDebugFrameworkIosSimulatorArm64\`, \`:composeApp:compileDevDebugKotlinAndroid\`, \`:composeApp:compileKotlinDesktop\` — all clean
- [x] \`AuthViewModelTest\` — 19/22 green; 3 red (\`first biometric failure...\`, \`second biometric failure...\`, \`successful biometric auth...\`) all call the stubbed methods, exactly as expected
- [x] No regressions elsewhere
- [ ] Backend implements \`onPasskeyScreenEntered()\`/\`onPasskeyRetry()\` (depends on \`PasskeyManager\`, #60, also still stubbed)
- [ ] Frontend builds the \`PasskeyPrompt\` composable (AUTH-04/04b/04c) — not started