### PR TITLE
Builder: implement PasswordStrengthValidator per the algorithm in the TDD

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -18,6 +18,13 @@
     <string name="auth_toggle_to_signup">New to Basil? Create account</string>
     <string name="auth_toggle_to_signin">Already have an account? Sign in</string>
 
+    <!-- ── Password strength requirements ────────────────────── -->
+    <string name="auth_req_length">8+ characters</string>
+    <string name="auth_req_uppercase">Uppercase letter (A–Z)</string>
+    <string name="auth_req_lowercase">Lowercase letter (a–z)</string>
+    <string name="auth_req_number">Number (0–9)</string>
+    <string name="auth_req_special">Special character (!@#$…)</string>
+
     <!-- ── Bottom navigation ─────────────────────────────────── -->
     <string name="nav_profile">Profile</string>
     <string name="nav_chat">Chat</string>

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SqlDelightUserRepository.kt
@@ -23,7 +23,7 @@ class SqlDelightUserRepository(private val database: BasilDatabase) : UserReposi
         database.userQueries.selectAll().executeAsList().map { it.toDomain() }
 
     override fun getAllAsFlow(): Flow<List<User>> =
-        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.IO).map { list ->
+        database.userQueries.selectAll().asFlow().mapToList(Dispatchers.Default).map { list ->
             list.map { it.toDomain() }
         }
 

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/auth/PasswordStrength.kt
@@ -1,5 +1,11 @@
 package org.weekendware.basil.presentation.auth
 
+import basil.composeapp.generated.resources.Res
+import basil.composeapp.generated.resources.auth_req_length
+import basil.composeapp.generated.resources.auth_req_lowercase
+import basil.composeapp.generated.resources.auth_req_number
+import basil.composeapp.generated.resources.auth_req_special
+import basil.composeapp.generated.resources.auth_req_uppercase
 import org.jetbrains.compose.resources.StringResource
 
 /**
@@ -23,8 +29,7 @@ sealed class PasswordStrength {
 /**
  * One row in the live requirements checklist shown below the strength bar.
  *
- * @property label Copy string identifying the requirement — pending Copywriter
- *   pass (`Res.string.auth_req_*`); not referenced by the validator stub below.
+ * @property label Copy string identifying the requirement.
  * @property met   True once the candidate password satisfies this requirement.
  */
 data class PasswordRequirement(val label: StringResource, val met: Boolean)
@@ -42,15 +47,26 @@ data class PasswordRequirement(val label: StringResource, val met: Boolean)
  * Strength mapping: `met.size` 0–2 → [PasswordStrength.Weak], 3–4 →
  * [PasswordStrength.Medium], 5 → [PasswordStrength.Strong]. An empty password
  * returns [PasswordStrength.None] paired with an empty requirements list.
- *
- * **Not implemented here.** This signature is QA scaffolding so
- * `PasswordStrengthValidatorTest` compiles and runs (red) ahead of
- * implementation. Backend Builder implements the body per the algorithm
- * documented above; every test in that suite is expected to fail with
- * `NotImplementedError` until then.
  */
 object PasswordStrengthValidator {
     fun validate(password: String): Pair<PasswordStrength, List<PasswordRequirement>> {
-        TODO("Not yet implemented — see tdd-splash-auth-07222026.md, AC18")
+        if (password.isEmpty()) return PasswordStrength.None to emptyList()
+
+        val requirements = listOf(
+            PasswordRequirement(Res.string.auth_req_length, password.length >= 8),
+            PasswordRequirement(Res.string.auth_req_uppercase, password.any { it.isUpperCase() }),
+            PasswordRequirement(Res.string.auth_req_lowercase, password.any { it.isLowerCase() }),
+            PasswordRequirement(Res.string.auth_req_number, password.any { it.isDigit() }),
+            PasswordRequirement(Res.string.auth_req_special, password.any { !it.isLetterOrDigit() }),
+        )
+
+        val metCount = requirements.count { it.met }
+        val strength = when {
+            metCount <= 2 -> PasswordStrength.Weak
+            metCount <= 4 -> PasswordStrength.Medium
+            else          -> PasswordStrength.Strong
+        }
+
+        return strength to requirements
     }
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
@@ -17,7 +17,7 @@ import kotlin.test.assertTrue
 class SplashGateTest {
 
     @Test
-    fun `shows splash while session is loading, even when fade is done`() {
+    fun `shows splash while session is loading even when fade is done`() {
         assertTrue(shouldShowSplash(SessionState.Loading, splashFadeDone = true))
     }
 

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/auth/PasswordStrengthValidatorTest.kt
@@ -10,13 +10,10 @@ import kotlin.test.assertTrue
  * classification (Weak/Medium/Strong), the length and special-character
  * boundaries, and requirement-list shape and determinism.
  *
- * All cases are expected to fail with `NotImplementedError` until Backend
- * Builder implements [PasswordStrengthValidator.validate].
- *
- * Deliberately does not assert on [PasswordRequirement.label] — copy is
- * pending a Copywriter pass and is out of scope for this validator's
- * contract. Tests assert only on strength classification, `met` values,
- * and list shape/order.
+ * Deliberately does not assert on [PasswordRequirement.label] contents —
+ * only that a label exists — since Copywriter owns the exact wording.
+ * Tests assert on strength classification, `met` values, and list
+ * shape/order.
  */
 class PasswordStrengthValidatorTest {
 
@@ -28,12 +25,15 @@ class PasswordStrengthValidatorTest {
     }
 
     @Test
-    fun `password meeting zero requirements is Weak`() {
-        // Below length, no uppercase, no digit, no special char.
+    fun `password meeting exactly one requirement is Weak`() {
+        // "abc" meets only lowercase. Meeting literally zero of the five is
+        // impossible for any non-empty password — every character is upper,
+        // lower, digit, or special, so at least one requirement always holds.
+        // The empty-password case above is the only true "nothing met" state.
         val (strength, requirements) = PasswordStrengthValidator.validate("abc")
         assertEquals(PasswordStrength.Weak, strength)
         assertEquals(5, requirements.size)
-        assertTrue(requirements.none { it.met })
+        assertEquals(1, requirements.count { it.met })
     }
 
     @Test
@@ -115,7 +115,7 @@ class PasswordStrengthValidatorTest {
     }
 
     @Test
-    fun `requirements list has exactly one entry per requirement, in a fixed order`() {
+    fun `requirements list has exactly one entry per requirement in a fixed order`() {
         // An all-digit, 8-character password meets only length and number —
         // no letters means no uppercase/lowercase, and digits don't count as
         // special characters. met=true should land at exactly those two

--- a/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
+++ b/composeApp/src/desktopTest/kotlin/org/weekendware/basil/presentation/profile/ProfileViewModelTest.kt
@@ -2,6 +2,8 @@ package org.weekendware.basil.presentation.profile
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
@@ -114,6 +116,7 @@ private class FakeUserRepository : UserRepository {
     var storedAvatarUrl: String? = null
 
     override fun getAll(): List<User> = listOfNotNull(currentUser)
+    override fun getAllAsFlow(): Flow<List<User>> = flowOf(getAll())
     override fun insert(id: String, name: String, email: String) { currentUser = User(id, name, email) }
     override fun updateAvatarUrl(userId: String, url: String?) { storedAvatarUrl = url }
     override fun deleteAll() { currentUser = null; storedAvatarUrl = null }


### PR DESCRIPTION
## Summary
Turns #53's QA scaffold green. Implements the algorithm exactly as documented: length ≥8, has-uppercase, has-lowercase, has-digit, has-special (any non-alphanumeric), Weak at 0–2 met, Medium at 3–4, Strong at 5, empty password → None. Added the \`auth_req_*\` string resources using the exact wording already in the approved mockup.

## Two real bugs found and fixed while verifying (not assuming green)

1. **QA test bug in #53**: \`"password meeting zero requirements is Weak"\` used \`"abc"\` and asserted \`requirements.none { it.met }\` — but \`"abc"\` is all lowercase, so it trivially meets that requirement. More fundamentally, meeting *zero* of five is impossible for any non-empty password (every character is upper/lower/digit/special, so something always matches). Renamed to "meeting exactly one requirement," fixed the assertion.

2. **Pre-existing iOS test-compile bug, unrelated to this PR**: this file's and \`SplashGateTest\`'s test names had commas inside backtick-quoted function names — Kotlin/Native rejects commas there (\`Name contains illegal characters\`). The iOS test target has apparently never successfully compiled its test sources in this project's history as a result. Distinct from #58's \`Dispatchers.IO\` fix, which only covered iOS *main* sources — I'd never actually verified iOS *test* compilation until this branch. Renamed both test names.

## Test plan
- [x] Android unit tests — green
- [x] iOS test sources compile clean — **first time this session** verifying this, not just main sources
- [x] Desktop compiles clean, full \`desktopTest\` suite green
- [ ] Could not execute iOS tests in this environment — linking fails on \`framework 'Sentry' not found\`, an environment/toolchain issue distinct from source correctness