### PR TITLE
Builder: full silent account provisioning routing + fix cold-launch crash

### DIFF
--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/App.kt
@@ -62,11 +62,14 @@ import org.weekendware.basil.presentation.chat.ChatScreen
 import org.weekendware.basil.presentation.more.MoreScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingScreen
 import org.weekendware.basil.presentation.onboarding.OnboardingViewModel
+import org.weekendware.basil.presentation.onboarding.SaveProgressScreen
 import org.weekendware.basil.presentation.profile.ProfileScreen
 import org.weekendware.basil.presentation.session.AuthenticatedDestination
 import org.weekendware.basil.presentation.session.SessionState
 import org.weekendware.basil.presentation.session.SessionViewModel
+import org.weekendware.basil.presentation.session.UnauthenticatedDestination
 import org.weekendware.basil.presentation.session.authenticatedDestination
+import org.weekendware.basil.presentation.session.unauthenticatedDestination
 import org.weekendware.basil.presentation.settings.SettingsScreen
 import org.weekendware.basil.presentation.splash.SplashScreen
 import org.weekendware.basil.presentation.theme.BasilTheme
@@ -108,7 +111,16 @@ fun App() {
                     SplashScreen(onFadeComplete = { splashDone = true })
                 } else {
                     when (val session = sessionState) {
-                        SessionState.Unauthenticated -> AuthFlowScreen()
+                        is SessionState.Unauthenticated -> when (unauthenticatedDestination(session)) {
+                            UnauthenticatedDestination.Onboarding -> {
+                                val onboardingViewModel = koinViewModel<OnboardingViewModel>()
+                                OnboardingScreen(viewModel = onboardingViewModel, modifier = Modifier.fillMaxSize())
+                            }
+                            UnauthenticatedDestination.SaveProgress ->
+                                SaveProgressScreen()
+                            UnauthenticatedDestination.Auth ->
+                                AuthFlowScreen()
+                        }
                         is SessionState.Authenticated -> when (authenticatedDestination(session)) {
                             AuthenticatedDestination.Normal ->
                                 AuthenticatedRoot(themeHour = themeHour)

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/data/repository/SupabaseAuthRepository.kt
@@ -109,8 +109,21 @@ class SupabaseAuthRepository(
     override suspend fun signInWithPasskey(): Result<Unit> =
         TODO("Not yet implemented — blocked on DevOps passkey domain prerequisites, see tdd-splash-auth-07222026.md, Passkeys on KMP")
 
+    /**
+     * Reads the `passkey_enrolled` flag per the TDD's data model — NOT a
+     * `TODO()` like the other two passkey methods. Unlike those (only
+     * reachable from user-triggered actions with no UI wired up yet),
+     * `AuthViewModel`'s `init` block calls this unconditionally on every
+     * cold launch to decide whether to show the biometric prompt. A
+     * `TODO()` here crashed the app on first launch — caught via an actual
+     * on-device run, never by the unit suite (which only ever exercises
+     * `FakeAuthRepository`). Since [registerPasskey] can't yet succeed to
+     * set this, it safely always reads `false` — the standard form shows,
+     * exactly like [org.weekendware.basil.data.repository.FakeAuthRepository]'s
+     * default. Not a passkey implementation, just a non-crashing stub.
+     */
     override fun hasPasskeyEnrolled(): Boolean =
-        TODO("Not yet implemented — blocked on DevOps passkey domain prerequisites, see tdd-splash-auth-07222026.md, passkey_enrolled key")
+        settings.getBoolean(Keys.PASSKEY_ENROLLED, false)
 
     /**
      * [DeepLinkHandler] has already validated [url] against
@@ -127,6 +140,7 @@ class SupabaseAuthRepository(
 
     private object Keys {
         const val LAST_USED_EMAIL = "stored_auth_email"
+        const val PASSKEY_ENROLLED = "passkey_enrolled"
     }
 
     override fun lastUsedEmail(): String? = settings.getStringOrNull(Keys.LAST_USED_EMAIL)

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/di/SharedModule.kt
@@ -24,6 +24,7 @@ import org.weekendware.basil.data.repository.SupabaseProfileRepository
 import org.weekendware.basil.data.repository.UserRepository
 import org.weekendware.basil.domain.usecase.GetUserUseCase
 import org.weekendware.basil.domain.usecase.SendMessageUseCase
+import org.weekendware.basil.domain.usecase.SyncOnboardingToSupabaseUseCase
 import org.weekendware.basil.presentation.auth.AuthViewModel
 import org.weekendware.basil.presentation.auth.NewPasswordViewModel
 import org.weekendware.basil.presentation.auth.ResetPasswordViewModel
@@ -63,6 +64,7 @@ val databaseModule = module {
 val useCaseModule = module {
     single { GetUserUseCase(get()) }
     single { SendMessageUseCase(get()) }
+    single { SyncOnboardingToSupabaseUseCase(get(), get(), get()) }
 }
 
 val onboardingModule = module {
@@ -71,13 +73,13 @@ val onboardingModule = module {
 }
 
 val sharedModule = module {
-    viewModel { SessionViewModel(get()) }
+    viewModel { SessionViewModel(get(), get()) }
     viewModel { AuthViewModel(get()) }
     viewModel { ResetPasswordViewModel(get()) }
     viewModel { NewPasswordViewModel(get()) }
     viewModel { VerificationWallViewModel(get()) }
     viewModel { OnboardingViewModel(get(), get(), get(), get()) }
-    viewModel { SaveProgressViewModel(get()) }
+    viewModel { SaveProgressViewModel(get(), get()) }
     viewModel { ProfileViewModel(get(), get(), get()) }
     viewModel { ChatViewModel(get(), get()) }
     viewModel { SettingsViewModel(get()) }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SyncOnboardingToSupabaseUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/domain/usecase/SyncOnboardingToSupabaseUseCase.kt
@@ -1,0 +1,28 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.coroutines.flow.first
+import org.weekendware.basil.data.repository.OnboardingLocalRepository
+import org.weekendware.basil.data.repository.ProfileRepository
+import org.weekendware.basil.data.repository.UserRepository
+
+/**
+ * Pushes the locally-completed onboarding answers to Supabase, once — called
+ * exactly once, right after a successful sign-up on [org.weekendware.basil.presentation.onboarding.SaveProgressScreen].
+ *
+ * Under full silent account provisioning, the entire onboarding conversation
+ * runs pre-auth with no `userId`, so [OnboardingViewModel][org.weekendware.basil.presentation.onboarding.OnboardingViewModel]
+ * never had one to push to [ProfileRepository] with. This is that deferred
+ * sync, run the moment an account — and therefore a `userId` — first exists.
+ */
+class SyncOnboardingToSupabaseUseCase(
+    private val onboardingLocalRepository: OnboardingLocalRepository,
+    private val profileRepository: ProfileRepository,
+    private val userRepository: UserRepository,
+) {
+    suspend operator fun invoke(userId: String, email: String): Result<Unit> {
+        val local = onboardingLocalRepository.state.first()
+        return profileRepository.upsertStep(userId, local).onSuccess {
+            userRepository.insert(id = userId, name = local.name.orEmpty(), email = email)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModel.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.StringResource
 import org.weekendware.basil.data.repository.AuthRepository
+import org.weekendware.basil.domain.usecase.SyncOnboardingToSupabaseUseCase
 import org.weekendware.basil.presentation.auth.PasswordRequirement
 import org.weekendware.basil.presentation.auth.PasswordStrength
 import org.weekendware.basil.presentation.auth.PasswordStrengthValidator
@@ -42,15 +43,20 @@ data class SaveProgressUiState(
 }
 
 /**
- * ViewModel for [SaveProgressScreen]. Only handles account creation itself
- * — syncing the already-collected local onboarding answers to Supabase
- * once the account exists is
- * [org.weekendware.basil.presentation.onboarding.OnboardingViewModel]'s job,
- * not this screen's, matching the TDD's `syncLocalToSupabase(userId)` call
- * "once, after successful sign-up."
+ * ViewModel for [SaveProgressScreen]. Handles account creation and the
+ * one-time sync of the already-collected local onboarding answers to
+ * Supabase once the account exists — [SyncOnboardingToSupabaseUseCase],
+ * matching the TDD's `syncLocalToSupabase(userId)` call "once, after
+ * successful sign-up." This is the only place that sync can happen:
+ * onboarding itself runs entirely pre-auth with no `userId` to sync to,
+ * and by the time this screen shows, the onboarding conversation is
+ * already over — nothing will call back into
+ * [org.weekendware.basil.presentation.onboarding.OnboardingViewModel] to
+ * trigger it from there.
  */
 class SaveProgressViewModel(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val syncOnboardingToSupabase: SyncOnboardingToSupabaseUseCase,
 ) : ViewModel() {
 
     private val _state = MutableStateFlow(SaveProgressUiState())
@@ -76,7 +82,12 @@ class SaveProgressViewModel(
     fun onSocialSignUpResult(result: NativeSignInResult) {
         when (result) {
             is NativeSignInResult.Success -> {
-                authRepository.currentUserEmail()?.let(authRepository::recordLastUsedEmail)
+                val email = authRepository.currentUserEmail()
+                email?.let(authRepository::recordLastUsedEmail)
+                val userId = authRepository.currentUserId()
+                if (userId != null && email != null) {
+                    viewModelScope.launch { syncOnboardingToSupabase(userId, email) }
+                }
                 _state.update { it.copy(isLoading = false) }
             }
             is NativeSignInResult.ClosedByUser -> _state.update { it.copy(isLoading = false) }
@@ -94,7 +105,11 @@ class SaveProgressViewModel(
         viewModelScope.launch {
             val result = authRepository.signUp(current.email, current.password)
             result.fold(
-                onSuccess = { _state.update { it.copy(isLoading = false) } },
+                onSuccess = {
+                    val userId = authRepository.currentUserId()
+                    if (userId != null) syncOnboardingToSupabase(userId, current.email)
+                    _state.update { it.copy(isLoading = false) }
+                },
                 onFailure = { _state.update { it.copy(isLoading = false, error = Res.string.error_auth_failed) } }
             )
         }

--- a/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/org/weekendware/basil/presentation/session/SessionViewModel.kt
@@ -4,9 +4,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.stateIn
 import org.weekendware.basil.data.repository.AuthRepository
+import org.weekendware.basil.data.repository.OnboardingLocalRepository
 
 /** Represents the resolved authentication state of the current session. */
 sealed interface SessionState {
@@ -26,8 +27,25 @@ sealed interface SessionState {
         val daysSinceSignup: Long,
     ) : SessionState
 
-    /** No session — the user must sign in. */
-    data object Unauthenticated : SessionState
+    /**
+     * No Supabase session exists. Full silent account provisioning means this
+     * alone doesn't determine what the user sees next — see
+     * [unauthenticatedDestination].
+     *
+     * @property onboardingComplete Whether the local (DataStore-persisted)
+     *   onboarding conversation has finished. Local state, not account state
+     *   — onboarding runs entirely pre-auth.
+     * @property hasAccount Whether this device has ever completed a real
+     *   sign-up/sign-in. Derived from [AuthRepository.lastUsedEmail] — the
+     *   same detect-by-email signal the auth screen already uses, repurposed
+     *   here as a "has this device provisioned an account before" proxy
+     *   rather than introducing a second persisted flag for a materially
+     *   similar question. Nothing currently clears it once set.
+     */
+    data class Unauthenticated(
+        val onboardingComplete: Boolean,
+        val hasAccount: Boolean,
+    ) : SessionState
 }
 
 /** Where an authenticated user lands once their verification status is known. */
@@ -47,35 +65,59 @@ fun authenticatedDestination(state: SessionState.Authenticated): AuthenticatedDe
         AuthenticatedDestination.Normal
     }
 
+/** Where an unauthenticated user lands — full silent account provisioning. */
+enum class UnauthenticatedDestination { Onboarding, SaveProgress, Auth }
+
+/**
+ * Pure routing decision for a user with no Supabase session. Onboarding runs
+ * entirely pre-auth and unconditionally comes first; only once it's done does
+ * account state matter. A user who finished onboarding but never created an
+ * account sees "save your progress" framing rather than a cold sign-in form.
+ * A user who has an account but is currently signed out (explicit sign-out,
+ * expired session) goes straight to the standard auth screen — onboarding is
+ * already done, there's nothing to save.
+ */
+fun unauthenticatedDestination(state: SessionState.Unauthenticated): UnauthenticatedDestination =
+    when {
+        !state.onboardingComplete -> UnauthenticatedDestination.Onboarding
+        !state.hasAccount -> UnauthenticatedDestination.SaveProgress
+        else -> UnauthenticatedDestination.Auth
+    }
+
 /**
  * App-root ViewModel that owns the single source of truth for auth state.
  *
- * Collects [AuthRepository.sessionFlow] and exposes [state] as a
- * [StateFlow] so [App] can decide which nav graph to display without
- * any Supabase-specific types leaking into the UI layer.
+ * Combines [AuthRepository.sessionFlow] with [OnboardingLocalRepository.state]
+ * and exposes [state] as a [StateFlow] so [App] can decide which nav graph to
+ * display without any Supabase-specific types leaking into the UI layer.
  *
  * The initial value is [SessionState.Loading] to prevent a visible
  * flash between the unauthenticated and authenticated screens while
  * the SDK restores a stored session on cold start.
  */
 class SessionViewModel(
-    private val authRepository: AuthRepository
+    private val authRepository: AuthRepository,
+    private val onboardingLocalRepository: OnboardingLocalRepository,
 ) : ViewModel() {
 
-    val state: StateFlow<SessionState> = authRepository.sessionFlow
-        .map { isSignedIn ->
-            if (isSignedIn) {
-                SessionState.Authenticated(
-                    isEmailVerified = authRepository.isEmailVerified(),
-                    daysSinceSignup = authRepository.daysSinceSignup(),
-                )
-            } else {
-                SessionState.Unauthenticated
-            }
+    val state: StateFlow<SessionState> = combine(
+        authRepository.sessionFlow,
+        onboardingLocalRepository.state,
+    ) { isSignedIn, onboarding ->
+        if (isSignedIn) {
+            SessionState.Authenticated(
+                isEmailVerified = authRepository.isEmailVerified(),
+                daysSinceSignup = authRepository.daysSinceSignup(),
+            )
+        } else {
+            SessionState.Unauthenticated(
+                onboardingComplete = onboarding.isComplete,
+                hasAccount = authRepository.lastUsedEmail() != null,
+            )
         }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.Eagerly,
-            initialValue = SessionState.Loading
-        )
+    }.stateIn(
+        scope = viewModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = SessionState.Loading
+    )
 }

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/SplashGateTest.kt
@@ -28,13 +28,13 @@ class SplashGateTest {
 
     @Test
     fun `shows splash when session resolved but fade not yet complete`() {
-        assertTrue(shouldShowSplash(SessionState.Unauthenticated, splashFadeDone = false))
+        assertTrue(shouldShowSplash(SessionState.Unauthenticated(onboardingComplete = true, hasAccount = true), splashFadeDone = false))
         assertTrue(shouldShowSplash(SessionState.Authenticated(isEmailVerified = true, daysSinceSignup = 0),   splashFadeDone = false))
     }
 
     @Test
     fun `hides splash when unauthenticated and fade is done`() {
-        assertFalse(shouldShowSplash(SessionState.Unauthenticated, splashFadeDone = true))
+        assertFalse(shouldShowSplash(SessionState.Unauthenticated(onboardingComplete = true, hasAccount = true), splashFadeDone = true))
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/SyncOnboardingToSupabaseUseCaseTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/domain/usecase/SyncOnboardingToSupabaseUseCaseTest.kt
@@ -1,0 +1,72 @@
+package org.weekendware.basil.domain.usecase
+
+import kotlinx.coroutines.test.runTest
+import org.weekendware.basil.data.repository.FakeOnboardingLocalRepository
+import org.weekendware.basil.data.repository.FakeProfileRepository
+import org.weekendware.basil.data.repository.FakeUserRepository
+import org.weekendware.basil.domain.model.DiagnosisDuration
+import org.weekendware.basil.domain.model.Goal
+import org.weekendware.basil.domain.model.ManagementType
+import org.weekendware.basil.domain.model.OnboardingPersistedState
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SyncOnboardingToSupabaseUseCaseTest {
+
+    private val onboardingLocalRepo = FakeOnboardingLocalRepository()
+    private val profileRepo = FakeProfileRepository()
+    private val userRepo = FakeUserRepository()
+    private val useCase = SyncOnboardingToSupabaseUseCase(onboardingLocalRepo, profileRepo, userRepo)
+
+    @Test
+    fun `pushes the completed local onboarding state to the profile repository`() = runTest {
+        onboardingLocalRepo.setState(
+            OnboardingPersistedState(
+                name = "Gavin",
+                managementType = ManagementType.PUMP,
+                diagnosisDuration = DiagnosisDuration.ONE_TO_FIVE,
+                goal = Goal.PATTERNS,
+                isComplete = true,
+            )
+        )
+
+        val result = useCase("uid-123", "gavin@example.com")
+
+        assertTrue(result.isSuccess)
+        assertEquals(1, profileRepo.upsertCalls.size)
+        assertEquals("Gavin", profileRepo.upsertCalls.single().name)
+    }
+
+    @Test
+    fun `inserts the local user row on successful sync`() = runTest {
+        onboardingLocalRepo.setState(OnboardingPersistedState(name = "Gavin", isComplete = true))
+
+        useCase("uid-123", "gavin@example.com")
+
+        val insert = userRepo.insertCalls.single()
+        assertEquals("uid-123", insert.id)
+        assertEquals("Gavin", insert.name)
+        assertEquals("gavin@example.com", insert.email)
+    }
+
+    @Test
+    fun `does not insert a user row when the profile upsert fails`() = runTest {
+        onboardingLocalRepo.setState(OnboardingPersistedState(name = "Gavin", isComplete = true))
+        profileRepo.upsertResult = Result.failure(Exception("network error"))
+
+        val result = useCase("uid-123", "gavin@example.com")
+
+        assertTrue(result.isFailure)
+        assertTrue(userRepo.insertCalls.isEmpty())
+    }
+
+    @Test
+    fun `blank name falls back to an empty string rather than the literal null`() = runTest {
+        onboardingLocalRepo.setState(OnboardingPersistedState(name = null, isComplete = true))
+
+        useCase("uid-123", "gavin@example.com")
+
+        assertEquals("", userRepo.insertCalls.single().name)
+    }
+}

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/onboarding/SaveProgressViewModelTest.kt
@@ -10,6 +10,11 @@ import basil.composeapp.generated.resources.Res
 import basil.composeapp.generated.resources.error_auth_failed
 import io.github.jan.supabase.compose.auth.composable.NativeSignInResult
 import org.weekendware.basil.data.repository.FakeAuthRepository
+import org.weekendware.basil.data.repository.FakeOnboardingLocalRepository
+import org.weekendware.basil.data.repository.FakeProfileRepository
+import org.weekendware.basil.data.repository.FakeUserRepository
+import org.weekendware.basil.domain.model.OnboardingPersistedState
+import org.weekendware.basil.domain.usecase.SyncOnboardingToSupabaseUseCase
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -30,13 +35,22 @@ class SaveProgressViewModelTest {
 
     private val dispatcher = UnconfinedTestDispatcher()
     private lateinit var repo: FakeAuthRepository
+    private lateinit var onboardingLocalRepo: FakeOnboardingLocalRepository
+    private lateinit var profileRepo: FakeProfileRepository
+    private lateinit var userRepo: FakeUserRepository
     private lateinit var viewModel: SaveProgressViewModel
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(dispatcher)
         repo = FakeAuthRepository()
-        viewModel = SaveProgressViewModel(repo)
+        onboardingLocalRepo = FakeOnboardingLocalRepository()
+        profileRepo = FakeProfileRepository()
+        userRepo = FakeUserRepository()
+        viewModel = SaveProgressViewModel(
+            repo,
+            SyncOnboardingToSupabaseUseCase(onboardingLocalRepo, profileRepo, userRepo),
+        )
     }
 
     @AfterTest
@@ -107,6 +121,19 @@ class SaveProgressViewModelTest {
     }
 
     @Test
+    fun `successful onCreateAccount syncs the local onboarding answers to Supabase`() = runTest {
+        onboardingLocalRepo.setState(OnboardingPersistedState(name = "Gavin", isComplete = true))
+        viewModel.onEmailChange("user@test.com")
+        viewModel.onPasswordChange("Abcdefg1!")
+
+        viewModel.onCreateAccount()
+
+        val insert = userRepo.insertCalls.single()
+        assertEquals("Gavin", insert.name)
+        assertEquals("user@test.com", insert.email)
+    }
+
+    @Test
     fun `failed onCreateAccount surfaces an error`() = runTest {
         repo.signUpResult = Result.failure(Exception("email already registered"))
         viewModel.onEmailChange("user@test.com")
@@ -131,6 +158,19 @@ class SaveProgressViewModelTest {
         assertFalse(state.isLoading)
         assertNull(state.error)
         assertEquals("fake@example.com", repo.lastUsedEmail())
+    }
+
+    @Test
+    fun `onSocialSignUpResult Success syncs the local onboarding answers to Supabase`() {
+        onboardingLocalRepo.setState(OnboardingPersistedState(name = "Gavin", isComplete = true))
+        repo.setSignedIn(true)
+        viewModel.onSocialSignUpStarted()
+
+        viewModel.onSocialSignUpResult(NativeSignInResult.Success)
+
+        val insert = userRepo.insertCalls.single()
+        assertEquals("Gavin", insert.name)
+        assertEquals("fake@example.com", insert.email)
     }
 
     @Test

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionStateRoutingTest.kt
@@ -4,10 +4,39 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 /**
- * QA test suite for [authenticatedDestination] — the pure routing decision
- * that gates the 30-day email-verification soft-block.
+ * QA test suite for [authenticatedDestination] and [unauthenticatedDestination]
+ * — the pure routing decisions for full silent account provisioning and the
+ * 30-day email-verification soft-block.
  */
 class SessionStateRoutingTest {
+
+    @Test
+    fun `onboarding-incomplete routes to Onboarding regardless of account state`() {
+        assertEquals(
+            UnauthenticatedDestination.Onboarding,
+            unauthenticatedDestination(SessionState.Unauthenticated(onboardingComplete = false, hasAccount = false)),
+        )
+        assertEquals(
+            UnauthenticatedDestination.Onboarding,
+            unauthenticatedDestination(SessionState.Unauthenticated(onboardingComplete = false, hasAccount = true)),
+        )
+    }
+
+    @Test
+    fun `onboarding-complete with no account routes to SaveProgress`() {
+        assertEquals(
+            UnauthenticatedDestination.SaveProgress,
+            unauthenticatedDestination(SessionState.Unauthenticated(onboardingComplete = true, hasAccount = false)),
+        )
+    }
+
+    @Test
+    fun `onboarding-complete with an existing account routes to Auth`() {
+        assertEquals(
+            UnauthenticatedDestination.Auth,
+            unauthenticatedDestination(SessionState.Unauthenticated(onboardingComplete = true, hasAccount = true)),
+        )
+    }
 
     @Test
     fun `verified user routes to Normal regardless of account age`() {

--- a/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
+++ b/composeApp/src/commonTest/kotlin/org/weekendware/basil/presentation/session/SessionViewModelTest.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.weekendware.basil.data.repository.FakeAuthRepository
+import org.weekendware.basil.data.repository.FakeOnboardingLocalRepository
+import org.weekendware.basil.domain.model.OnboardingPersistedState
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -17,13 +19,15 @@ class SessionViewModelTest {
 
     private val dispatcher = UnconfinedTestDispatcher()
     private lateinit var repo: FakeAuthRepository
+    private lateinit var onboardingLocalRepo: FakeOnboardingLocalRepository
     private lateinit var viewModel: SessionViewModel
 
     @BeforeTest
     fun setup() {
         Dispatchers.setMain(dispatcher)
         repo = FakeAuthRepository()
-        viewModel = SessionViewModel(repo)
+        onboardingLocalRepo = FakeOnboardingLocalRepository()
+        viewModel = SessionViewModel(repo, onboardingLocalRepo)
     }
 
     @AfterTest
@@ -33,7 +37,27 @@ class SessionViewModelTest {
 
     @Test
     fun `initial state is Unauthenticated when no session exists`() = runTest {
-        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Unauthenticated)
+    }
+
+    @Test
+    fun `Unauthenticated reflects onboarding-incomplete and no-account by default`() = runTest {
+        assertEquals(
+            SessionState.Unauthenticated(onboardingComplete = false, hasAccount = false),
+            viewModel.state.value,
+        )
+    }
+
+    @Test
+    fun `Unauthenticated reflects a returning signed-out user with a completed onboarding and an account`() = runTest {
+        onboardingLocalRepo.setState(OnboardingPersistedState(isComplete = true))
+        repo.recordLastUsedEmail("user@example.com")
+        viewModel = SessionViewModel(repo, onboardingLocalRepo)
+
+        assertEquals(
+            SessionState.Unauthenticated(onboardingComplete = true, hasAccount = true),
+            viewModel.state.value,
+        )
     }
 
     @Test
@@ -46,7 +70,7 @@ class SessionViewModelTest {
     fun `state returns to Unauthenticated when session is cleared`() = runTest {
         repo.setSignedIn(true)
         repo.setSignedIn(false)
-        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Unauthenticated)
     }
 
     @Test
@@ -54,7 +78,7 @@ class SessionViewModelTest {
         repo.setSignedIn(true)
         assertEquals(true, viewModel.state.value is SessionState.Authenticated)
         repo.signOut()
-        assertEquals(SessionState.Unauthenticated, viewModel.state.value)
+        assertEquals(true, viewModel.state.value is SessionState.Unauthenticated)
     }
 
     @Test


### PR DESCRIPTION
## Summary

Two things, bundled because I found the crash while testing this feature on a physical device.

## 1. Cold-launch crash fix

Building on a OnePlus 9 Pro surfaced a real bug: the app crashed on every cold launch. `AuthViewModel`'s `init` calls `authRepository.hasPasskeyEnrolled()` eagerly, and that was still `TODO()` on the real `SupabaseAuthRepository`. Unlike the other passkey stubs (only reachable from UI that was never built), this one runs unconditionally on every launch — the unit suite never caught it because every test uses `FakeAuthRepository`, which safely defaults to `false`. Fixed by reading the flag from the same settings store backing `lastUsedEmail`, defaulting to `false` — not a passkey implementation, just a non-crashing stub. Verified on the physical device: launches and stays open now.

## 2. Full silent account provisioning routing

Also confirmed live on device: a fresh install landed on a login screen with no way to sign up, because `OnboardingScreen` only ever rendered inside the authenticated shell — backwards from the TDD (onboarding should run pre-auth, account creation deferred to "save your progress").

- `SessionState.Unauthenticated` extended to carry `onboardingComplete`/`hasAccount`, same pattern as `Authenticated`'s verification-wall extension.
- New pure `unauthenticatedDestination()`: onboarding-incomplete → Onboarding; complete + no account → SaveProgress; otherwise → Auth. `hasAccount` reuses the existing `lastUsedEmail()` detect-by-email signal rather than adding a second persisted flag for a materially similar question.
- `SessionViewModel` combines `sessionFlow` with `OnboardingLocalRepository.state`.
- `App.kt` routes accordingly. Left `AuthenticatedRoot`'s own onboarding fallback alone — confirmed it's not dead code, it's the real safety net for a returning user on a new device while their remote profile is still fetching.
- New `SyncOnboardingToSupabaseUseCase`, called once from `SaveProgressViewModel` after a successful sign-up (both email/password and social paths) — the deferred push of locally-collected onboarding answers, since there's never a `userId` to push to during pre-auth onboarding itself.
- Confirmed `OnboardingViewModel` already guards every Supabase call with `if (userId != null)` — that part of the TDD's requirement was already correct.

## Test plan
- [x] `:composeApp:testDevDebugUnitTest`, `:composeApp:desktopTest` — 246 tests, 3 failures (pre-existing documented passkey biometric reds) — zero new failures, 11 new tests all green
- [x] `:composeApp:linkDebugFrameworkIosSimulatorArm64`, `:composeApp:compileTestKotlinIosSimulatorArm64` — both clean
- [x] Rebuilt and reinstalled on a physical OnePlus 9 Pro — confirmed the crash fix
- [ ] Full routing flow not yet re-verified on device after the routing change — session ended before reconnecting
