### PR TITLE
Docs: drop 'Chapter:' prefix from doc headings

### DIFF
--- a/.github/chapters/auth.md
+++ b/.github/chapters/auth.md
@@ -1,6 +1,6 @@
 ← [Back to README](../../README.md) · Previous: [← Basil Theme](theme.md)
 
-# Chapter: Auth
+# Auth
 
 Basil's auth system is built around one idea: the conversation comes first. A brand-new user never sees a login screen before they've talked to Basil — onboarding runs entirely before any account exists, and account creation happens at the end, framed as "save your progress," not "sign up."
 

--- a/.github/chapters/theme.md
+++ b/.github/chapters/theme.md
@@ -1,6 +1,6 @@
 ← [Back to README](../../README.md)
 
-# Chapter: The Basil Theme
+# The Basil Theme
 
 The day/night cycle is core to Basil's identity — not a theme setting, not dark mode. It's always on. Color, tone, and lighting shift through four periods of the day, and the app is meant to feel alive because it responds to the actual moment the user is in, not a generic session state.
 


### PR DESCRIPTION
## Summary
- Auth doc heading was "# Chapter: Auth", Theme doc heading was "# Chapter: The Basil Theme" — both still had the word "chapter" baked into the visible page title even after it was removed from README links. Changed to plain "# Auth" and "# The Basil Theme".

## Test plan
- [x] Grepped both docs and README.md for "chapter" (case-insensitive) — only remaining matches are the `.github/chapters/` folder path, not display text