### PR TITLE
Docs: strip em dashes and AI-era buzzwords from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Basil
 *Built by WeekendWare*
 
-Type 1 Diabetes doesn't pause. It's there at 2am when your CGM alerts. It's there before a run, before a meal, in every conversation where you have to explain yourself. People living with T1D carry a cognitive load that most health apps make heavier — tracking inputs, logging outputs, reducing a life to data points.
+Type 1 Diabetes doesn't pause. It's there at 2am when your CGM alerts. It's there before a run, before a meal, in every conversation where you have to explain yourself. People living with T1D carry a cognitive load that most health apps make heavier, tracking inputs, logging outputs, reducing a life to data points.
 
-Basil is built on a different premise. Not a tracker. A companion. Something that knows what your days actually look like, remembers what you've shared, and is worth talking to — when you have a question, a hard moment, or just need to think out loud.
+Basil is built on a different premise. Not a tracker. A companion. Something that knows what your days actually look like, remembers what you've shared, and is worth talking to when you have a question, a hard moment, or just need to think out loud.
 
-The conversation is the product. Everything else is infrastructure.
+The conversation is the product. Everything else just supports it.
 
 ---
 
@@ -13,16 +13,16 @@ The conversation is the product. Everything else is infrastructure.
 
 - **[The Basil Theme](.github/chapters/theme.md)**
 - **[Auth](.github/chapters/auth.md)**
-- **Conversation-first** — no forms, no dashboards, no BG numbers. The entire interface is a conversation.
-- **Persistent memory** — a real, evolving picture of who someone is, not a session that resets every time they open the app.
-- **Time-of-day presence** — color, tone, and lighting shift through the day, so the app feels like it's actually there with the user.
-- **A hard boundary** — never medical advice, never a data point. Support, not supervision.
+- **Conversation-first.** No forms, no dashboards, no BG numbers. The entire interface is a conversation.
+- **Persistent memory.** A real, evolving picture of who someone is, not a session that resets every time they open the app.
+- **Time-of-day presence.** Color, tone, and lighting shift through the day, so the app feels like it's actually there with the user.
+- **A hard boundary.** Never medical advice, never a data point. Support, not supervision.
 
 ---
 
 ## Why this matters
 
-There are roughly 9 million people living with Type 1 Diabetes globally. Most of them are already expert patients — they've been managing this since childhood. What they don't have is something that understands them as a whole person rather than a set of metrics.
+There are roughly 9 million people living with Type 1 Diabetes globally. Most of them are already expert patients, managing this since childhood. What they don't have is something that understands them as a whole person rather than a set of metrics.
 
 Basil isn't a replacement for a care team. It's the thing you can talk to at 11pm that doesn't require an appointment.
 
@@ -46,7 +46,7 @@ The market for AI-powered chronic condition companions is early and largely unoc
 | Date/Time | kotlinx-datetime 0.6.0 |
 | Crash reporting | Sentry Kotlin Multiplatform 0.25.0 |
 | Static analysis | Detekt 1.23.7 + detekt-formatting |
-| Testing | kotlin-test + Turbine — hand-written `Fake*Repository` test doubles, no mocking framework |
+| Testing | kotlin-test + Turbine, hand-written `Fake*Repository` test doubles, no mocking framework |
 
 Kotlin Multiplatform targeting Android, iOS, and Desktop from a single shared codebase.
 
@@ -59,34 +59,34 @@ domain/usecase/        Single-responsibility use cases
 data/repository/       Repository interfaces + SQLDelight / Supabase implementations
 data/local/database/   SQLDelight schema, queries, DatabaseDriverFactory
 data/remote/           Ktor-based API client (chat)
-di/                    Koin modules — shared + platform-specific
+di/                    Koin modules, shared + platform-specific
 ```
 
 Each layer depends only on the layer below it. ViewModels and use cases depend on repository *interfaces*, keeping them testable without a real database. ViewModels extend `androidx.lifecycle.ViewModel` and are scoped to their nav destination via `koinViewModel<T>()`.
 
 ### What's built
 
-**App infrastructure**
-- **Auth** — see [Auth](.github/chapters/auth.md)
-- **Navigation** — state-based routing driven by `AnimatedContent` and pure functions (`unauthenticatedDestination()`, `authenticatedDestination()`) rather than a navigation library; bottom tab bar (Profile, Chat, More); Settings slides in as a full-screen overlay via `graphicsLayer` translation
-- **Theme** — see [The Basil Theme](.github/chapters/theme.md)
-- **Crash reporting** — Sentry across all three targets with `PhiScrubber` stripping health data before any event leaves the device
-- **CI/CD** — GitHub Actions running Detekt, Android compile + test, and iOS framework build on every push
+**Core systems**
+- **Auth.** Details in [Auth](.github/chapters/auth.md).
+- **Navigation.** State-based routing driven by `AnimatedContent` and pure functions (`unauthenticatedDestination()`, `authenticatedDestination()`) rather than a navigation library; bottom tab bar (Profile, Chat, More); Settings slides in as a full-screen overlay via `graphicsLayer` translation.
+- **Theme.** Details in [The Basil Theme](.github/chapters/theme.md).
+- **Crash reporting.** Sentry across all three targets, with `PhiScrubber` stripping health data before any event leaves the device.
+- **CI/CD.** GitHub Actions running Detekt, Android compile + test, and iOS framework build on every push.
 
 **Screens**
-- **Chat** — streaming conversation screen wired to the companion API, with a dismissible email-verification banner
-- **Onboarding** — conversational first-run flow, runs entirely pre-auth (name, management type, how long they've had T1D, what they're hoping for)
-- **Save your progress** — account creation at the end of onboarding, not the start
-- **Profile** — name, email, and profile photo
-- **Settings** — notifications placeholder, app version, sign out
+- **Chat.** Streaming conversation screen wired to the companion API, with a dismissible email-verification banner.
+- **Onboarding.** Conversational first-run flow that runs entirely pre-auth (name, management type, how long they've had T1D, what they're hoping for).
+- **Save your progress.** Account creation at the end of onboarding, not the start.
+- **Profile.** Name, email, and profile photo.
+- **Settings.** Notifications placeholder, app version, sign out.
 
 ### PHI Protection
 
 T1D apps handle sensitive health data. Basil scrubs it before it can leave the device via [`PhiScrubber`](composeApp/src/commonMain/kotlin/org/weekendware/basil/crash/PhiScrubber.kt):
 
 - User identity is removed from every Sentry event
-- Exception messages from health-related packages (`chat`, `data`, `auth`) are cleared — exception type and stack trace are preserved for debugging
-- Breadcrumb data payloads are wiped — navigation category and type are kept
+- Exception messages from health-related packages (`chat`, `data`, `auth`) are cleared, though exception type and stack trace are preserved for debugging
+- Breadcrumb data payloads are wiped, though navigation category and type are kept
 
 This is table stakes for any health product. It ships from day one, not as a compliance afterthought.
 
@@ -96,18 +96,18 @@ This is table stakes for any health product. It ships from day one, not as a com
 
 The foundation is in. What ships next is the core product.
 
-- [ ] **Passkeys** — the contract and biometric-attempt UI states are scaffolded and tested, but implementation is blocked on DevOps prerequisites (`apple-app-site-association` / `assetlinks.json` on a live production domain) — see [Auth](.github/chapters/auth.md)
-- [ ] **Check-in system** — Basil reaches out. You respond. That exchange is stored and becomes the basis for everything that follows.
-- [ ] **Persistent memory** — Basil builds a real picture of this person over time. Not a summary. A context.
-- [ ] **Chat history sync** — conversation history not yet persisted to Supabase; each session is stateless
-- [ ] **HIPAA hardening** — SQLCipher, session timeout, audit log
+- [ ] **Passkeys.** The contract and biometric-attempt UI states are scaffolded and tested, but implementation is blocked on DevOps prerequisites (`apple-app-site-association` / `assetlinks.json` on a live production domain). Details in [Auth](.github/chapters/auth.md).
+- [ ] **Check-in system.** Basil reaches out, you respond, and that exchange is stored and becomes the basis for everything that follows.
+- [ ] **Persistent memory.** Basil builds a real picture of this person over time. Not a summary. A context.
+- [ ] **Chat history sync.** Conversation history not yet persisted to Supabase; each session is stateless.
+- [ ] **HIPAA hardening.** SQLCipher, session timeout, audit log.
 - [ ] **Push notifications**
 - [ ] **RevenueCat subscription + message caps**
-- [ ] **Desktop persistence** — file-backed SQLite driver
+- [ ] **Desktop persistence.** File-backed SQLite driver.
 
 **Already shipped**
 - [x] Build flavors (dev / staging / prod)
-- [x] Full silent account provisioning — onboarding runs pre-auth, account creation deferred to "save your progress"
+- [x] Full silent account provisioning, onboarding runs pre-auth, account creation deferred to "save your progress"
 - [x] Email/password + native Google/Apple sign-in, email verification, password reset, sign-out
 - [x] Conversational onboarding
 - [x] Time-of-day color system with animated transitions
@@ -132,7 +132,7 @@ Requires Java 21. If `java -version` shows Java 26 or later, prefix with `JAVA_H
 ./gradlew :composeApp:run
 ```
 
-**iOS** — open `iosApp/iosApp.xcodeproj` in Xcode and run on any iOS 18.2+ simulator.
+**iOS.** Open `iosApp/iosApp.xcodeproj` in Xcode and run on any iOS 18.2+ simulator.
 
 > `Sentry.xcframework` (Sentry Cocoa 8.57.3) must be present at `iosApp/Sentry.xcframework`. Download from the [sentry-cocoa releases](https://github.com/getsentry/sentry-cocoa/releases/tag/8.57.3) and unzip into `iosApp/`.
 


### PR DESCRIPTION
## Summary
- Removed all 29 em dashes from README.md and replaced them with commas, periods, or restructured clauses per WeekendWare's writing style rules (no em dashes, they're an AI tell)
- Bullet list items that used "**Label** — description" now use "**Label.** Description" instead
- Replaced "infrastructure" as a description of the app itself (in two spots) with concrete language, per the flagged AI-era-buzzword pattern

## Test plan
- [x] `grep -c "—" README.md` returns 0
- [x] `grep -i infrastructure README.md` returns no matches
- [x] Rendered README.md locally, confirmed nothing reads awkwardly after the rewrite